### PR TITLE
Use more recent keepalived with a ubuntu ppa

### DIFF
--- a/README.md
+++ b/README.md
@@ -20,6 +20,11 @@ The main variables are:
 * keepalived_sync_groups: This is a mandatory dict. It groups items defined in keepalived_instances, and (if desired) allow the configuration of notifications scripts per group of keepalived_instances. Notification scripts are triggered on keepalived's state change and are facultative.
 * keepalived_scripts: This is an optional dict where you could have checking scripts that can trigger the notifications scripts.
 * keepalived_bind_on_non_local: This variable (defaulted to "False") determines whether the system that host keepalived will allow its apps to bind on non-local addresses. If you set it to true, this allows apps to bind (and start) even if they don't currently have the VIP for example.
+* keepalived_use_latest_stable_ppa: (Default: True) When this setting is set to False, the role will use the package provided with the distribution instead of using the ppa.
+* keepalived_repo: The url to the repo for installing keepalived.
+* keepalived_repo_keyid: The keyid for the repo for installing keepalived.
+* keepalived_repo_keyurl: The key url of the repo.
+* cache_timeout: This is the expiration time of the apt cache. When expired, apt will automatically update its cache. This variable will be removed when the ansible bug upstream will be fixed.
 
 Please check the examples for more explanations on how these dicts must be configured.
 

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+## APT Cache options
+cache_timeout: 600
+
 keepalived_instances: []
 keepalived_sync_groups: []
 keepalived_bind_on_non_local: False

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -19,3 +19,8 @@ cache_timeout: 600
 keepalived_instances: []
 keepalived_sync_groups: []
 keepalived_bind_on_non_local: False
+keepalived_use_latest_stable_ppa: True
+keepalived_repo: "ppa:keepalived/stable"
+keepalived_repo_keyid: "7C33BDC6"
+#keepalived_repo_keyurl:
+keepalived_keyserver: keyserver.ubuntu.com

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,23 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+#TODO(evrardjp): Replace the next 2 tasks by a standard apt with cache
+#when https://github.com/ansible/ansible-modules-core/pull/1517 is merged
+#in 1.9.x or we move to 2.0 (if tested working)
+- name: Check apt last update file
+  stat:
+    path: /var/cache/apt
+  register: apt_cache_stat
+  tags:
+    - keepalived-apt-packages
+
+- name: Update apt if needed
+  apt:
+    update_cache: yes
+  when: "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}"
+  tags:
+    - keepalived-apt-packages
+
 - name: install keepalived
   apt:
     pkg: keepalived

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -13,6 +13,26 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+- name: Add the keepalived apt repository key
+  apt_key:
+    id: "{{ keepalived_repo_keyid }}"
+    #url: "{{ keepalived_repo_keyurl }}"
+    keyserver: "{{ keepalived_keyserver }}"
+    state: present
+  when: keepalived_use_latest_stable_ppa | bool
+  tags:
+    - keepalived-apt-keys
+
+- name: Add the keepalived apt repository
+  apt_repository:
+    repo: "{{ keepalived_repo }}"
+    update_cache: True
+    state: present
+  when: keepalived_use_latest_stable_ppa | bool
+  register: add_apt_repository
+  tags:
+    - keepalived-repo
+
 #TODO(evrardjp): Replace the next 2 tasks by a standard apt with cache
 #when https://github.com/ansible/ansible-modules-core/pull/1517 is merged
 #in 1.9.x or we move to 2.0 (if tested working)
@@ -26,7 +46,9 @@
 - name: Update apt if needed
   apt:
     update_cache: yes
-  when: "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}"
+  when: >
+    "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}" or
+    add_apt_repository|changed
   tags:
     - keepalived-apt-packages
 


### PR DESCRIPTION
This introduces the use of a ppa for installing keepalived by default.
This behaviour can be reversed by adapting the variable "keepalived_use_latest_stable_ppa"