### PR TITLE
Rewrite the multi-os support

### DIFF
--- a/README.md
+++ b/README.md
@@ -16,19 +16,14 @@ Examples are given in the vars folder. Don't try them immediately, they won't wo
 
 The main variables are:
 
-* keepalived_use_latest_stable: This is by default set to false. When set to true, the role will always install latest version of keepalived, making it restart when a new version appears in the ppa.
 * keepalived_instances: This is a mandatory dict. It gathers information about the vips, the prefered state (master/backup), the VRRIP IDs and priorities, the password used for authentication... This is where things like nopreempt are configured. nopreempt allows to stay in backup state (instead of preempting to configured master) on a master return of availability, after its failure. Please check the template for additional settings support, and original keepalived documentation for their configuration.
 * keepalived_sync_groups: This is a mandatory dict. It groups items defined in keepalived_instances, and (if desired) allow the configuration of notifications scripts per group of keepalived_instances. Notification scripts are triggered on keepalived's state change and are facultative.
 * keepalived_scripts: This is an optional dict where you could have checking scripts that can trigger the notifications scripts.
 * keepalived_bind_on_non_local: This variable (defaulted to "False") determines whether the system that host keepalived will allow its apps to bind on non-local addresses. If you set it to true, this allows apps to bind (and start) even if they don't currently have the VIP for example.
-* keepalived_use_latest_stable_ppa: (Default: True) When this setting is set to False, the role will use the package provided with the distribution instead of using the ppa.
-* keepalived_repo: The url to the repo for installing keepalived.
-* keepalived_repo_keyid: The keyid for the repo for installing keepalived.
-* keepalived_repo_keyurl: The key url of the repo.
-* cache_timeout: This is the expiration time of the apt cache. When expired, apt will automatically update its cache. This variable will be removed when the ansible bug upstream will be fixed.
 
 Please check the examples for more explanations on how these dicts must be configured.
 
+Other editable variables are listed in the defaults/main.yml. Please read the explanation there if you want to override them.
 An example of a notification script is also given, in the files folder.
 
 Dependencies
@@ -44,17 +39,11 @@ Here is how you could use the role
     - hosts: keepalived_servers[0]
       vars_files:
         - roles/keepalived/vars/keepalived_haproxy_master_example.yml
-      pre_tasks:
-        - apt:
-            update_cache: yes
       roles:
          - keepalived
     - hosts: keepalived_hosts:!keepalived_hosts[0]
       vars_files:
         - roles/keepalived/vars/keepalived_haproxy_backup_example.yml
-      pre_tasks:
-        - apt:
-            update_cache: yes
       roles:
          - keepalived
 

--- a/UPGRADE.md
+++ b/UPGRADE.md
@@ -1,0 +1,2 @@
+- Starting from 2.0, you must use keepalived_use_external_repo instead of keepalived_use_latest_stable_ppa in order to use an external repository
+- Starting from 2.0, the external repo is hard set for the user.

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,15 +13,22 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-## APT Cache options
+#This is the expiration time of your package manager cache.
+#When expired, this role will require to update the package manger cache.
+#This variable will be removed when the ansible upstream bugs will be fixed.
 cache_timeout: 600
 
+# This is the variable to ensure the state of the package on your system.
+# When False, the role will only make sure a package is installed.
+# When True, the role will always install latest version of the
+#   keepalived package, making it restart when a new version appears.
 keepalived_use_latest_stable: False
+
+# This variable used to be called keepalived_use_latest_stable_ppa
+# When this setting is set to False, the role will use the package
+# provided with the distribution instead of using an external source.
+keepalived_use_external_repo: True
+
 keepalived_instances: []
 keepalived_sync_groups: {}
 keepalived_bind_on_non_local: False
-keepalived_use_latest_stable_ppa: True
-keepalived_repo: "ppa:keepalived/stable"
-keepalived_repo_keyid: "7C33BDC6"
-#keepalived_repo_keyurl:
-keepalived_keyserver: keyserver.ubuntu.com

--- a/tasks/keepalived_install_apt.yml
+++ b/tasks/keepalived_install_apt.yml
@@ -16,10 +16,10 @@
 - name: Add the keepalived apt repository key
   apt_key:
     id: "{{ keepalived_repo_keyid }}"
-    #url: "{{ keepalived_repo_keyurl }}"
-    keyserver: "{{ keepalived_keyserver }}"
+    url: "{{ keepalived_repo_keyurl | default(omit)}}"
+    keyserver: "{{ keepalived_keyserver | default(omit) }}"
     state: present
-  when: keepalived_use_latest_stable_ppa | bool
+  when: keepalived_use_external_repo | bool
   tags:
     - keepalived-apt-keys
 
@@ -28,7 +28,7 @@
     repo: "{{ keepalived_repo }}"
     update_cache: True
     state: present
-  when: keepalived_use_latest_stable_ppa | bool
+  when: keepalived_use_external_repo | bool
   register: add_apt_repository
   tags:
     - keepalived-repo
@@ -47,7 +47,7 @@
   apt:
     update_cache: yes
   when: >
-    "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{cache_timeout}}" or
+    "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{ apt_cache_timeout }}" or
     add_apt_repository|changed
   tags:
     - keepalived-apt-packages
@@ -63,7 +63,16 @@
 
 - name: install keepalived
   apt:
-    pkg: keepalived
+    pkg: "{{ keepalived_package_name }}"
     state: "{{ keepalived_use_latest_stable | bool | ternary('latest','present') }}"
   tags:
     - keepalived-apt-packages
+
+- name: Allow keepalived from starting on install
+  file:
+    path: /etc/init/keepalived.override
+    state: absent
+  changed_when: False
+  tags:
+    - keepalived-config
+    - keepalived-prevent-start

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -39,7 +39,7 @@
 - name: configure keepalived
   template:
     src: keepalived.conf.j2
-    dest: /etc/keepalived/keepalived.conf
+    dest: "{{ keepalived_config_file_path }}"
   tags:
     - keepalived-config
   notify:
@@ -94,14 +94,3 @@
   when: item.value.src_notify_fault is defined
   notify:
     - restart keepalived
-
-- name: Allow keepalived from starting on install
-  file:
-    path: /etc/init/keepalived.override
-    state: absent
-  changed_when: False
-  when:
-    - ansible_pkg_mgr == 'apt'
-  tags:
-    - keepalived-config
-    - keepalived-prevent-start

--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -12,3 +12,18 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+
+## APT Cache options
+apt_cache_timeout: "{{ cache_timeout }}"
+
+#Standard names and paths for ubuntu 14.04
+keepalived_package_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+
+## Repo details for ubuntu 14.04
+# repo, keyid are mandatory.
+# One of (keyurl or keyserver) is required
+keepalived_repo: "ppa:keepalived/stable"
+keepalived_repo_keyid: "7C33BDC6"
+#keepalived_repo_keyurl:
+keepalived_keyserver: "keyserver.ubuntu.com"


### PR DESCRIPTION
Multi-OS support was included in previous commit, but variable names
didn't make sense anymore.

This should fix this.

Signed-off-by: Jean-Philippe Evrard <jean-philippe@evrard.me>