### PR TITLE
fix example usage in README.md

### DIFF
--- a/README.md
+++ b/README.md
@@ -36,7 +36,7 @@ Example Playbook
 
 Here is how you could use the role
 
-    - hosts: keepalived_servers[0]
+    - hosts: keepalived_hosts[0]
       vars_files:
         - roles/keepalived/vars/keepalived_haproxy_master_example.yml
       roles:


### PR DESCRIPTION
Both keepalived_servers and keepalived_hosts was being used. This
commit fixes both examples to use keepalived_hosts to aid clarity.