### PR TITLE
Introduced Ubuntu Cloud Archive installation method

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,12 @@ keepalived_use_latest_stable: False
 # provided with the distribution instead of using an external source.
 keepalived_use_external_repo: True
 
+# This variables changes the external repo used for ubuntu. If set
+# to true, it will use the ubuntu cloud archive as external repo.
+# If set to False, it will use the ppa as external repo.
+keepalived_uca_enable: False
+uca_apt_repo_url: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
+
 keepalived_instances: []
 keepalived_sync_groups: {}
 keepalived_bind_on_non_local: False

--- a/tasks/keepalived_install_apt.yml
+++ b/tasks/keepalived_install_apt.yml
@@ -19,7 +19,9 @@
     url: "{{ keepalived_repo_keyurl | default(omit)}}"
     keyserver: "{{ keepalived_keyserver | default(omit) }}"
     state: present
-  when: keepalived_use_external_repo | bool
+  when:
+    - keepalived_use_external_repo | bool
+    - not keepalived_uca_enable | bool
   tags:
     - keepalived-apt-keys
 
@@ -28,10 +30,30 @@
     repo: "{{ keepalived_repo }}"
     update_cache: True
     state: present
-  when: keepalived_use_external_repo | bool
+  when:
+    - keepalived_use_external_repo | bool
+    - not keepalived_uca_enable | bool
   register: add_apt_repository
   tags:
     - keepalived-repo
+
+- name: Add Ubuntu Cloud Archive keyring
+  apt:
+    pkg: ubuntu-cloud-keyring
+    state: "latest"
+  register: add_uca_keys
+  when:
+    - keepalived_use_external_repo | bool
+    - keepalived_uca_enable | bool
+
+- name: Add Ubuntu Cloud Archive Repository
+  apt_repository:
+    repo: "{{ uca_repo }}"
+    update_cache: True
+    state: present
+  when:
+    - keepalived_use_external_repo | bool
+    - keepalived_uca_enable | bool
 
 #TODO(evrardjp): Replace the next 2 tasks by a standard apt with cache
 #when https://github.com/ansible/ansible-modules-core/pull/1517 is merged

--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -20,10 +20,15 @@ apt_cache_timeout: "{{ cache_timeout }}"
 keepalived_package_name: "keepalived"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
 
-## Repo details for ubuntu 14.04
+## Repo details for keepalived ppa
 # repo, keyid are mandatory.
 # One of (keyurl or keyserver) is required
 keepalived_repo: "ppa:keepalived/stable"
 keepalived_repo_keyid: "7C33BDC6"
 #keepalived_repo_keyurl:
 keepalived_keyserver: "keyserver.ubuntu.com"
+
+## Repo details for keepalived uca
+uca_repo: "deb {{ uca_apt_repo_url }} {{ uca_repo_dist }} main"
+uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ uca_openstack_release }}"
+uca_openstack_release: mitaka

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -1,0 +1,34 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+## APT Cache options
+apt_cache_timeout: "{{ cache_timeout }}"
+
+#Standard names and paths for ubuntu 14.04
+keepalived_package_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+
+## Repo details for keepalived ppa
+# repo, keyid are mandatory.
+# One of (keyurl or keyserver) is required
+keepalived_repo: "ppa:keepalived/stable"
+keepalived_repo_keyid: "7C33BDC6"
+#keepalived_repo_keyurl:
+keepalived_keyserver: "keyserver.ubuntu.com"
+
+## Repo details for keepalived uca
+uca_repo: "deb {{ uca_apt_repo_url }} {{ uca_repo_dist }} main"
+uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ uca_openstack_release }}"
+uca_openstack_release: newton


### PR DESCRIPTION
Instead of using a ppa, some deployers may want to use ubuntu cloud
archive to install keepalived.

This commit introduces two variables to change the default behavior (of
installing with ppa): keepalived_uca_enable and uca_apt_repo_url

The first variable is defaulted to false, and if set to true, keepalived
will be installed with ubuntu cloud archive.
The second variable is the url to the uca repository, which can be
overriden if you want to define your own mirror of the uca repository
(Defaults to: "http://ubuntu-cloud.archive.canonical.com/ubuntu")

Signed-off-by: Jean-Philippe Evrard <jean-philippe@evrard.me>