### PR TITLE
Fix typo in update apt condititional

### DIFF
--- a/tasks/keepalived_install_apt.yml
+++ b/tasks/keepalived_install_apt.yml
@@ -69,7 +69,7 @@
   apt:
     update_cache: yes
   when: >
-    "ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > {{ apt_cache_timeout }}" or
+    ansible_date_time.epoch|float - apt_cache_stat.stat.mtime > apt_cache_timeout or
     add_apt_repository|changed
   tags:
     - keepalived-apt-packages


### PR DESCRIPTION
Ansible 2.2 is now less indulgent to typos compared to previous versions.
The conditional in the apt update task was incorrect and "False" or False
returned True.

This fixes it.

As a summary, ansible now behave correctly. Woot! 
(Please insert rainbows and unicorns)

Signed-off-by: Jean-Philippe Evrard <jean-philippe@evrard.me>