### PR TITLE
added optional virtual_server config

### DIFF
--- a/README.md
+++ b/README.md
@@ -18,7 +18,7 @@ The main variables are:
 
 * keepalived_instances: This is a mandatory dict. It gathers information about the vips, the prefered state (master/backup), the VRRIP IDs and priorities, the password used for authentication... This is where things like nopreempt are configured. nopreempt allows to stay in backup state (instead of preempting to configured master) on a master return of availability, after its failure. Please check the template for additional settings support, and original keepalived documentation for their configuration.
 * keepalived_sync_groups: This is a mandatory dict. It groups items defined in keepalived_instances, and (if desired) allow the configuration of notifications scripts per group of keepalived_instances. Notification scripts are triggered on keepalived's state change and are facultative.
-* keepalived_virtual_servers: This is an optional dict. It sets up a virtual server + port and balances traffic over real_servers given in a sub dict. Checkout the example files in vars/ to see an example.
+* keepalived_virtual_servers: This is an optional dict. It sets up a virtual server + port and balances traffic over real_servers given in a sub dict. Checkout the _example.yaml files in vars/ to see a sample on how to use this dict. The official documentation for keepalived's virtual_server can be found [here](https://github.com/acassen/keepalived/blob/master/doc/keepalived.conf.SYNOPSIS#L393).
 * keepalived_scripts: This is an optional dict where you could have checking scripts that can trigger the notifications scripts.
 * keepalived_bind_on_non_local: This variable (defaulted to "False") determines whether the system that host keepalived will allow its apps to bind on non-local addresses. If you set it to true, this allows apps to bind (and start) even if they don't currently have the VIP for example.
 
@@ -26,6 +26,8 @@ Please check the examples for more explanations on how these dicts must be confi
 
 Other editable variables are listed in the defaults/main.yml. Please read the explanation there if you want to override them.
 An example of a notification script is also given, in the files folder.
+
+Antoher good source of informations is the official keepalived [GIT repo](https://github.com/acassen/keepalived) where you can find a fully commented [keepalived.conf](https://github.com/acassen/keepalived/blob/master/doc/keepalived.conf.SYNOPSIS). Also various official samples are [provided](https://github.com/acassen/keepalived/tree/master/doc/samples).
 
 Dependencies
 ------------

--- a/README.md
+++ b/README.md
@@ -18,6 +18,7 @@ The main variables are:
 
 * keepalived_instances: This is a mandatory dict. It gathers information about the vips, the prefered state (master/backup), the VRRIP IDs and priorities, the password used for authentication... This is where things like nopreempt are configured. nopreempt allows to stay in backup state (instead of preempting to configured master) on a master return of availability, after its failure. Please check the template for additional settings support, and original keepalived documentation for their configuration.
 * keepalived_sync_groups: This is a mandatory dict. It groups items defined in keepalived_instances, and (if desired) allow the configuration of notifications scripts per group of keepalived_instances. Notification scripts are triggered on keepalived's state change and are facultative.
+* keepalived_virtual_servers: This is an optional dict. It sets up a virtual server + port and balances traffic over real_servers given in a sub dict. Checkout the example files in vars/ to see an example.
 * keepalived_scripts: This is an optional dict where you could have checking scripts that can trigger the notifications scripts.
 * keepalived_bind_on_non_local: This variable (defaulted to "False") determines whether the system that host keepalived will allow its apps to bind on non-local addresses. If you set it to true, this allows apps to bind (and start) even if they don't currently have the VIP for example.
 

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -110,3 +110,40 @@ vrrp_instance {{ name }} {
   {% endif %}
 }
 {% endfor %}
+
+{% if keepalived_virtual_servers is defined %}
+{% for vserver in keepalived_virtual_servers %}
+virtual_server {{ vserver.ip }} {{ vserver.port }} {
+  ip_family {{ vserver.ip_family | default('inet') }}
+  {% if vserver.delay_loop is defined %}
+  delay_loop {{ vserver.delay_loop }}
+  {% endif %}
+  lvs_sched {{ vserver.lvs_sched | default ('rr') }}
+  lvs_method {{ vserver.lvs_method | default ('DR') }}
+  protocol {{ vserver.protocol | default ('TCP') }}
+  {% if vserver.ha_suspend is defined and vserver.ha_suspend %}
+  ha_suspend
+  {% endif %}
+
+  {% for rserver in vserver.real_servers %}
+  real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% if rserver.misc_check is defined %}
+    {% for mcheck in rserver.misc_check %}
+    MISC_CHECK {
+      misc_path "{{ mcheck.misc_path }}"
+      misc_timeout {{ mcheck.misc_timeout | default('3') }}
+      {% if mcheck.warmup is defined and mcheck.warmup %}
+      warmup
+      {% endif %}
+      {% if mcheck.misc_dynamic is defined and mcheck.misc_dynamic %}
+      misc_dynamic
+      {% endif %}
+    }
+    {% endfor %}
+    {% endif %}
+  }
+  {% endfor %}
+
+}
+{% endfor %}
+{% endif %}

--- a/vars/keepalived_haproxy_backup_example.yml
+++ b/vars/keepalived_haproxy_backup_example.yml
@@ -99,3 +99,30 @@ keepalived_instances:
     #  - eth2
     vips:
       - "{{ keepalived_internal_vip_cidr | default('127.0.3.1') }} dev {{ keepalived_internal_interface | default('eth1') }} "
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - ip: '8.8.8.8'
+#        port: '53'
+#        # Currently on MISC_CHECK is supported. Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - ip: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              misc_timeout: '10'
+#              # Optinal, set false or omit to not use it.
+#              warmup: true
+#              # Optinal, set false or omit to not use it.
+#              misc_dynamic: true

--- a/vars/keepalived_haproxy_master_example.yml
+++ b/vars/keepalived_haproxy_master_example.yml
@@ -99,3 +99,30 @@ keepalived_instances:
     #  - eth2
     vips:
       - "{{keepalived_internal_vip_cidr}} dev eth1"
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - ip: '8.8.8.8'
+#        port: '53'
+#        # Currently on MISC_CHECK is supported. Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - ip: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              misc_timeout: '10'
+#              # Optinal, set false or omit to not use it.
+#              warmup: true
+#              # Optinal, set false or omit to not use it.
+#              misc_dynamic: true


### PR DESCRIPTION
Hello @evrardjp,

this PR enables the user to define virtual_servers with this role. We plan to use it in our new internal DNS infrastructure.
Please let me know if something can be done better.
I mostly used [the officlal git repo](https://github.com/acassen/keepalived/blob/v1.2.23/doc/keepalived.conf.SYNOPSIS) to determine the required syntax. If you like I can also add a link to the official repo in the README.md.

Thank you and best regards

Jard