### PR TITLE
Add CentOS 7 support

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -19,6 +19,9 @@ galaxy_info:
   license: Apache
   min_ansible_version: 1.9
   platforms:
+  - name: EL
+    versions:
+    - 7
   - name: Ubuntu
     versions:
     - trusty

--- a/tasks/keepalived_install_yum.yml
+++ b/tasks/keepalived_install_yum.yml
@@ -13,7 +13,16 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-# Standard names and paths for CentOS 7
-keepalived_package_name: "keepalived"
-keepalived_service_name: "keepalived"
-keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+- name: Ensure that the EPEL repository is available
+  yum:
+    pkg: epel-release
+    state: present
+  tags:
+    - keepalived-yum-packages
+
+- name: Install keepalived
+  yum:
+    pkg: "{{ keepalived_package_name }}"
+    state: "{{ keepalived_use_latest_stable | bool | ternary('latest','present') }}"
+  tags:
+    - keepalived-yum-packages

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,12 @@
   tags:
     - install-apt
 
+- include: keepalived_install_yum.yml
+  when:
+    - ansible_pkg_mgr == 'yum'
+  tags:
+    - install-yum
+
 - name: Allow consuming apps to bind on non local addresses
   sysctl:
     name: net.ipv4.ip_nonlocal_bind


### PR DESCRIPTION
This patch adds CentOS 7 support for the keepalived role.