### PR TITLE
Fix latest service name

### DIFF
--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -18,7 +18,7 @@ apt_cache_timeout: "{{ cache_timeout }}"
 
 #Standard names and paths for ubuntu 14.04
 keepalived_package_name: "keepalived"
-keepalived_service_name: "keepalived"
+keepalived_service_name: "keepalived.service"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
 
 ## Repo details for keepalived ppa


### PR DESCRIPTION
Latest ppa changed the name of service from ``keepalived`` to
``keepalived.service``.. It should be safe to use
``keepalived.service`` for all the systemd versions, therefore
we are moving to it.