### PR TITLE
keepalived do not need epel.

### DIFF
--- a/tasks/keepalived_install_yum.yml
+++ b/tasks/keepalived_install_yum.yml
@@ -13,13 +13,6 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-- name: Ensure that the EPEL repository is available
-  yum:
-    pkg: epel-release
-    state: present
-  tags:
-    - keepalived-yum-packages
-
 - name: Install keepalived
   yum:
     pkg: "{{ keepalived_package_name }}"


### PR DESCRIPTION
https://rpmfind.net/linux/RPM/centos/7.3.1611/x86_64/Packages/keepalived-1.2.13-8.el7.x86_64.html