### PR TITLE
Adding timeout attribute for check script

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -42,6 +42,7 @@ vrrp_script {{ name }} {
   interval "{{ details.interval | default(5) }}"   # checking every "{{ details.interval | default(5) }}" seconds (default: 5 seconds)
   fall "{{ details.fall | default(3) }}"           # require "{{ details.fall | default(3) }}" failures for KO (default: 3)
   rise "{{ details.rise | default(6) }}"           # require "{{ details.rise | default(6) }}" successes for OK (default: 6)
+  timeout {{ details.timeout | default(2) }}       # allow scripts like ping to succeed, before timing out (default: 2 seconds)
 }
 {% endfor %}
 {% endif %}

--- a/vars/keepalived_haproxy_backup_example.yml
+++ b/vars/keepalived_haproxy_backup_example.yml
@@ -55,6 +55,9 @@ keepalived_sync_groups:
     #fall: 2
     # Rise is the time to mark the keepalived status as back to ok
     #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
+
 
 keepalived_instances:
   #This dict name is the same as the one above, in keepalived_sync_groups.

--- a/vars/keepalived_haproxy_master_example.yml
+++ b/vars/keepalived_haproxy_master_example.yml
@@ -55,6 +55,8 @@ keepalived_sync_groups:
     #fall: 2
     # Rise is the time to mark the keepalived status as back to ok
     #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
 
 keepalived_instances:
   #This dict name is the same as the one above, in keepalived_sync_groups.


### PR DESCRIPTION
This fix adds the timeout attribute for check scripts to allow execution beyond 0seconds, which is particularly important for ping checks with used more than one ICMP packet to verify connectivity