### PR TITLE
Support for virtual routes for VRRP instances

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -80,6 +80,20 @@ vrrp_instance {{ name }} {
     {{ vip }}
     {% endfor %}
   }
+  {% if instance.virtual_routes is defined %}
+  virtual_routes {
+  {% for route in instance.virtual_routes %}
+    {{ route }}
+  {% endfor %}
+  }
+  {% endif %}
+  {% if instance.track_scripts is defined %}
+  track_script {
+    {% for track_script in instance.track_scripts %}
+    {{ track_script }}
+    {% endfor %}
+  }
+  {% endif %}  
   {% if instance.track_scripts is defined %}
   track_script {
     {% for track_script in instance.track_scripts %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -93,13 +93,6 @@ vrrp_instance {{ name }} {
     {{ track_script }}
     {% endfor %}
   }
-  {% endif %}  
-  {% if instance.track_scripts is defined %}
-  track_script {
-    {% for track_script in instance.track_scripts %}
-    {{ track_script }}
-    {% endfor %}
-  }
   {% endif %}
 
   {% if instance.track_interfaces is defined %}


### PR DESCRIPTION
Extended template to support virtual routes for VRRP, adding routes if becoming master, deleting them for backup.