### PR TITLE
set missing value after warmup key

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -143,7 +143,7 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
       misc_path "{{ mcheck.misc_path }}"
       misc_timeout {{ mcheck.misc_timeout | default('3') }}
       {% if mcheck.warmup is defined and mcheck.warmup %}
-      warmup
+      warmup {{ mcheck.warmup }}
       {% endif %}
       {% if mcheck.misc_dynamic is defined and mcheck.misc_dynamic %}
       misc_dynamic


### PR DESCRIPTION
Hello @evrardjp,

here comes a small fix on the warmup setting on the misc_check's.
According to the official [documentation](https://github.com/acassen/keepalived/blob/master/doc/keepalived.conf.SYNOPSIS#L688) a integer value needs to be provided after the keyword.

Best

Jard