### PR TITLE
Fix ansible lint issue

### DIFF
--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -27,7 +27,7 @@
 - name: Add Ubuntu Cloud Archive keyring
   apt:
     pkg: ubuntu-cloud-keyring
-    state: "latest"
+    state: "{{ keepalived_package_state }}"
   when:
     - ansible_pkg_mgr == 'apt'
     - keepalived_ubuntu_src == "uca"


### PR DESCRIPTION
Ansible lint issue ANSIBLE 0010 is appearing here, requiring the
package state to be present. If a deployer deploys with UCA,
it makes sense to always have the latest version of the UCA
keyring, when making sure it will install the latest version of
the package.