### PR TITLE
SELinux: allow keepalived to cat haproxy pid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -29,6 +29,11 @@ keepalived_ubuntu_src: "{{ (keepalived_uca_enable is defined and (keepalived_uca
 # If using UCA, you may want to point with your local mirror of UCA.
 keepalived_uca_apt_repo_url: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 
+# If running keepalived with SELinux, you could need to compile your
+# rules. Please override this list with path to files to compile.
+keepalived_selinux_compile_rules:
+  - keepalived_ping
+
 # TODO(evrardjp), 2017-11:
 # Remove the deprecation conditional and provide a good unconditional
 # default:

--- a/files/keepalived_haproxy_pid_file.te
+++ b/files/keepalived_haproxy_pid_file.te
@@ -1,0 +1,23 @@
+# Copyright 2017, Rackspace US, Inc.
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+module keepalived_haproxy_pid_file 1.0;
+
+require {
+    type haproxy_var_run_t;
+    type keepalived_t;
+    class file { getattr open read };
+}
+
+#============= keepalived_t ==============
+allow keepalived_t haproxy_var_run_t:file { getattr open read };

--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -31,8 +31,6 @@
     - '"keepalived_ping" not in selinux_modules.stdout'
 
 - include: keepalived_selinux_compile.yml
-  with_items:
-    - "keepalived_haproxy_pid_file"
-    - "keepalived_ping"
+  with_items: "{{ keepalived_selinux_compile_rules }}"
   loop_control:
     loop_var: selinux_policy_name

--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -30,39 +30,9 @@
   when:
     - '"keepalived_ping" not in selinux_modules.stdout'
 
-- name: Create directory for compiling SELinux role
-  file:
-    path: /tmp/ansible-keepalived-selinux/
-    state: directory
-    mode: '0755'
-  when:
-    - '"keepalived_ping" not in selinux_modules.stdout'
-
-- name: Deploy SELinux policy source file
-  copy:
-    src: keepalived_ping.te
-    dest: /tmp/ansible-keepalived-selinux/keepalived_ping.te
-    owner: root
-    group: root
-    mode: "0755"
-  when:
-    - '"keepalived_ping" not in selinux_modules.stdout'
-
-- name: Compile and load SELinux module
-  command: "{{ item }}"
-  args:
-    creates: /etc/selinux/targeted/active/modules/400/keepalived_ping/cil
-    chdir: /tmp/ansible-keepalived-selinux
+- include: keepalived_selinux_compile.yml
   with_items:
-    - checkmodule -M -m -o keepalived_ping.mod keepalived_ping.te
-    - semodule_package -o keepalived_ping.pp -m keepalived_ping.mod
-    - semodule -i keepalived_ping.pp
-  when:
-    - '"keepalived_ping" not in selinux_modules.stdout'
-
-- name: Remove temporary directory
-  file:
-    path: /tmp/ansible-keepalived-selinux/
-    state: absent
-  when:
-    - '"keepalived_ping" not in selinux_modules.stdout'
+    - "keepalived_haproxy_pid_file"
+    - "keepalived_ping"
+  loop_control:
+    loop_var: selinux_policy_name

--- a/tasks/keepalived_selinux_compile.yml
+++ b/tasks/keepalived_selinux_compile.yml
@@ -1,0 +1,51 @@
+---
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+- name: Create directory for compiling SELinux role
+  file:
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    state: directory
+    mode: '0755'
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Deploy SELinux policy source file
+  copy:
+    src: "{{ selinux_policy_name }}.te"
+    dest: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}/{{ selinux_policy_name }}.te"
+    owner: root
+    group: root
+    mode: "0755"
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Compile and load SELinux module
+  command: "{{ item }}"
+  args:
+    creates: "/etc/selinux/targeted/active/modules/400/{{ selinux_policy_name }}/cil"
+    chdir: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+  with_items:
+    - checkmodule -M -m -o {{ selinux_policy_name }}.mod {{ selinux_policy_name }}.te
+    - semodule_package -o {{ selinux_policy_name }}.pp -m {{ selinux_policy_name }}.mod
+    - semodule -i {{ selinux_policy_name }}.pp
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
+
+- name: Remove temporary directory
+  file:
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    state: absent
+  when:
+    - selinux_policy_name not in selinux_modules.stdout


### PR DESCRIPTION
On CentOS 7, an SELinux denial occurs when keepalived tries to read
haproxy's PID file. This patch adds SELinux policy to allow this
activity and breaks the SELinux compilation part of the role into
a reusable set of tasks.