### PR TITLE
Fix SELinux AVC when using setpgid

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -33,6 +33,7 @@ keepalived_uca_apt_repo_url: "http://ubuntu-cloud.archive.canonical.com/ubuntu"
 # rules. Please override this list with path to files to compile.
 keepalived_selinux_compile_rules:
   - keepalived_ping
+  - keepalived_setpgid
 
 # TODO(evrardjp), 2017-11:
 # Remove the deprecation conditional and provide a good unconditional

--- a/files/keepalived_setpgid.te
+++ b/files/keepalived_setpgid.te
@@ -1,0 +1,23 @@
+# Copyright 2017, Major Hayden <major@mhtx.net>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+module keepalived_setpgid 1.0;
+
+require {
+        type keepalived_t;
+        class process setpgid;
+}
+
+#============= keepalived_t ==============
+allow keepalived_t self:process setpgid;


### PR DESCRIPTION
When keepalived tries to set the progress group with the setpgid()
call, the access is denied by SELinux. This patch allows keepalived
to make the syscall.

Closes-Bug: https://bugs.launchpad.net/openstack-ansible/+bug/1732521