### PR TITLE
Mask systemd service for Ubuntu 16.04 during install

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,3 +17,11 @@
   service:
     name: "{{ keepalived_service_name }}"
     state: restarted
+
+- name: "Reload systemd"
+  systemd:
+    daemon_reload: yes
+  listen: "systemctl-daemon-reload"
+  when:
+    - ansible_service_mgr is defined
+    - ansible_service_mgr == 'systemd'

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -59,6 +59,19 @@
   when:
     - ansible_os_family | lower == 'debian'
     - check_if_present | changed
+    - prevent_start_mask_systemd is not defined
+  tags:
+    - keepalived-prevent-start
+
+- name: Prevent keepalived from starting on install - systemd mask
+  file:
+    state: link
+    src: "/dev/null"
+    dest: "{{ prevent_start_file }}"
+  when:
+    - ansible_os_family | lower == 'debian'
+    - check_if_present | changed
+    - prevent_start_mask_systemd is defined
   tags:
     - keepalived-prevent-start
 
@@ -81,3 +94,9 @@
   tags:
     - keepalived-config
     - keepalived-prevent-start
+
+- name: "Reload systemd if we deleted service mask"
+  systemd:
+    daemon_reload: yes
+  when:
+    - prevent_start_mask_systemd is defined

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -59,7 +59,8 @@
   when:
     - ansible_os_family | lower == 'debian'
     - check_if_present | changed
-    - prevent_start_mask_systemd is not defined
+    - ansible_service_mgr is defined
+    - ansible_service_mgr != 'systemd'
   tags:
     - keepalived-prevent-start
 
@@ -71,7 +72,8 @@
   when:
     - ansible_os_family | lower == 'debian'
     - check_if_present | changed
-    - prevent_start_mask_systemd is defined
+    - ansible_service_mgr is defined
+    - ansible_service_mgr == 'systemd'
   tags:
     - keepalived-prevent-start
 
@@ -83,6 +85,7 @@
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
   tags:
     - keepalived-apt-packages
+  notify: "systemctl-daemon-reload"
 
 - name: Revert keepalived start prevention
   file:
@@ -94,9 +97,3 @@
   tags:
     - keepalived-config
     - keepalived-prevent-start
-
-- name: "Reload systemd if we deleted service mask"
-  systemd:
-    daemon_reload: yes
-  when:
-    - prevent_start_mask_systemd is defined

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -29,5 +29,5 @@ keepalived_uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ keepalived_uca_
 keepalived_uca_openstack_release: ocata
 
 ## Prevent start on install
-prevent_start_file: "/usr/sbin/policy-rc.d"
-prevent_start_file_content: "exit 101"
+prevent_start_file: "/etc/systemd/system/keepalived.service"
+prevent_start_mask_systemd: true

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -30,4 +30,4 @@ keepalived_uca_openstack_release: ocata
 
 ## Prevent start on install
 prevent_start_file: "/etc/systemd/system/keepalived.service"
-prevent_start_mask_systemd: true
+prevent_start_file_content: false


### PR DESCRIPTION
Previous method of disabling keepalived from starting during install did
not work
Fix #18 in Virtualbox/Vagrant