### PR TITLE
Improve robustness of Vagrant tests

### DIFF
--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -2,9 +2,13 @@
 - hosts: keepalived2
   gather_facts: no
   tasks:
-    - raw: sudo apt-get install -y python
+    - name: Install python2
+      raw: sudo apt-get update && sudo apt install -y python
+      changed_when: false
 
 - hosts: all
+  # please comment order: sorted for 2.3 and below
+  order: sorted
   gather_facts: yes
   become: true
   become_method: sudo
@@ -17,17 +21,19 @@
         var: keepalived_instances
   roles:
     - ../ansible-keepalived
-
-- name: Check if first node is master
-  hosts: keepalived1
-  gather_facts: yes
-  become: true
-  become_method: sudo
-  tasks:
-    - assert:
+  post_tasks:
+    - name: Wait a few seconds to ensure that network connectivity is up
+      wait_for:
+        timeout: 12
+    - name: Ensure the facts are up to date
+      setup:
+        gather_subset: network
+    - name: Ensure the first node is master
+      assert:
         that:
-          - "'ipv4_secondaries' in ansible_eth1"
-          - "ansible_eth1['ipv4_secondaries'][0]['address'] == '192.168.33.2'"
+          - "'ipv4_secondaries' in ansible_{{ vrrp_nic }}"
+          - "ansible_{{ vrrp_nic }}['ipv4_secondaries'][0]['address'] == '192.168.33.2'"
+      when: inventory_hostname == ansible_play_hosts[0]
 
 - name: Check if failover works
   hosts: all
@@ -49,5 +55,3 @@
         that:
           - "'192.168.33.2' in ansible_all_ipv4_addresses"
       when: inventory_hostname == ansible_play_hosts[2]
-    #- shell: ifconfig {{ vrrp_nic }} up || true
-    #  changed_when: false


### PR DESCRIPTION
The ansible_play_host is not ordered the same way at every run.
If the first node happen to be keepalived2 instead of 1 or 3, the
VRRP convergence test would fail, as the test was looking into
the presence of the VRRP master ip on the eth1 NIC, which is not
the NIC name for ubuntu 16.04.

This moves to use {{ vrrp_nic }} instead of hardcoding eth1, and
ensures as much as possible a deterministic order for ansible 2.4
runs.

On top of that, a vagrant provision done twice would report
the provisioning as "changed" instead of "ok", only because we
are using a raw task for installing python2 on the ubuntu 16.04
node, which is considered as the minimum to run ansible.
This task to install python2 shouldn't be
considered as a change of ansible-keepalived itself, and shouldn't
impact idempotency tests.