### PR TITLE
Update of PR53 with extra coverage

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -17,6 +17,11 @@ boxes = [
     {
         :name => "keepalived3",
         :eth1 => "192.168.33.12",
+        :image => "ubuntu/xenial64",
+    },
+    {
+        :name => "keepalived4",
+        :eth1 => "192.168.33.13",
         :image => "centos/7",
     }
 ]
@@ -51,13 +56,13 @@ Vagrant.configure(2) do |config|
       # Vagrant works serially and provision machines
       # serially. Each of them is unaware of the others.
       # Therefore, we should start provisioning only on last machine
-      if boxopts[:name] == "keepalived3"
+      if boxopts[:name] == "keepalived4"
         config.vm.provision :ansible do |ansible|
           ansible.playbook = "tests/deploy.yml"
           ansible.extra_vars = "tests/keepalived_haproxy_combined_example.yml"
           ansible.limit = 'all'
           #ansible.inventory_path = "tests/inventory"
-          ansible.verbose = "-v"
+          ansible.verbose = "-vv"
           ansible.raw_ssh_args = ANSIBLE_RAW_SSH_ARGS
         end
       end

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,11 +17,3 @@
   service:
     name: "{{ keepalived_service_name }}"
     state: restarted
-
-- name: "Reload systemd"
-  systemd:
-    daemon_reload: yes
-  listen: "systemctl-daemon-reload"
-  when:
-    - ansible_service_mgr is defined
-    - ansible_service_mgr == 'systemd'

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,3 +17,11 @@
   service:
     name: "{{ keepalived_service_name }}"
     state: restarted
+
+- name: "Reload systemd"
+  systemd:
+    daemon_reload: yes
+  listen: "systemctl-daemon-reload"
+  when:
+    - ansible_service_mgr is defined
+    - ansible_service_mgr == 'systemd'

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -59,6 +59,21 @@
   when:
     - ansible_os_family | lower == 'debian'
     - check_if_present | changed
+    - ansible_service_mgr is defined
+    - ansible_service_mgr != 'systemd'
+  tags:
+    - keepalived-prevent-start
+
+- name: Prevent keepalived from starting on install - systemd mask
+  file:
+    state: link
+    src: "/dev/null"
+    dest: "{{ prevent_start_file }}"
+  when:
+    - ansible_os_family | lower == 'debian'
+    - check_if_present | changed
+    - ansible_service_mgr is defined
+    - ansible_service_mgr == 'systemd'
   tags:
     - keepalived-prevent-start
 
@@ -70,6 +85,7 @@
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
   tags:
     - keepalived-apt-packages
+  notify: "systemctl-daemon-reload"
 
 - name: Revert keepalived start prevention
   file:

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -52,7 +52,7 @@
   register: check_if_present
   check_mode: yes
 
-- name: Prevent keepalived from starting on install
+- name: Prevent keepalived from starting on install (upstart)
   copy:
     dest: "{{ prevent_start_file }}"
     content: "{{ prevent_start_file_content }}"
@@ -64,7 +64,7 @@
   tags:
     - keepalived-prevent-start
 
-- name: Prevent keepalived from starting on install - systemd mask
+- name: Prevent keepalived from starting on install (systemd)
   file:
     state: link
     src: "/dev/null"
@@ -85,7 +85,6 @@
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
   tags:
     - keepalived-apt-packages
-  notify: "systemctl-daemon-reload"
 
 - name: Ensure no new "samples" folder appeared
   file:
@@ -103,3 +102,12 @@
     - check_if_present | changed
   tags:
     - keepalived-prevent-start
+
+- name: "Systemd daemon_reload"
+  command: systemctl daemon-reload
+  changed_when: check_if_present | changed
+  when:
+    - ansible_service_mgr is defined
+    - ansible_service_mgr == 'systemd'
+  tags:
+    - skip_ansible_lint

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -87,6 +87,13 @@
     - keepalived-apt-packages
   notify: "systemctl-daemon-reload"
 
+- name: Ensure no new "samples" folder appeared
+  file:
+    path: /etc/keepalived/samples/
+    state: absent
+  when: 
+    - ansible_os_family | lower == 'debian'
+
 - name: Revert keepalived start prevention
   file:
     dest: "{{ prevent_start_file }}"
@@ -95,5 +102,4 @@
     - ansible_os_family | lower == 'debian'
     - check_if_present | changed
   tags:
-    - keepalived-config
     - keepalived-prevent-start

--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -1,9 +1,10 @@
 ---
-- hosts: keepalived2
+- name: Ubuntu nodes need python installed to run ansible
+  hosts: all:!keepalived4
   gather_facts: no
   tasks:
     - name: Install python2
-      raw: sudo apt-get update && sudo apt install -y python
+      raw: sudo apt-get update && sudo apt install -y python; sudo locale-gen en_GB.UTF-8
       changed_when: false
 
 - hosts: all
@@ -13,6 +14,9 @@
   become: true
   become_method: sudo
   pre_tasks:
+    - name: Define the nics to set up
+      set_fact:
+        vrrp_nic: "{{ ((ansible_interfaces | reject('equalto','lo')) | difference([ansible_default_ipv4.interface]))[0] | string }}"
     - name: Ensure the vrrp nics are up
       shell: ip link set dev {{ vrrp_nic }} up || true
       changed_when: false
@@ -43,7 +47,7 @@
   tasks:
     - shell: ifconfig {{ vrrp_nic }} down || true
       changed_when: false
-      when: inventory_hostname != ansible_play_hosts[2]
+      when: inventory_hostname != ansible_play_hosts[-1]
     - name: The VRRP state needs to adapt the topo change
       wait_for:
         timeout: 12
@@ -54,4 +58,4 @@
     - assert:
         that:
           - "'192.168.33.2' in ansible_all_ipv4_addresses"
-      when: inventory_hostname == ansible_play_hosts[2]
+      when: inventory_hostname == ansible_play_hosts[-1]

--- a/tests/group_vars/all.yml
+++ b/tests/group_vars/all.yml
@@ -1,2 +1,0 @@
----
-vrrp_nic: eth1

--- a/tests/host_vars/keepalived2.yml
+++ b/tests/host_vars/keepalived2.yml
@@ -1,2 +1,0 @@
----
-vrrp_nic: "{{ ansible_interfaces | reject('equalto','lo') | sort | last }}"

--- a/tests/host_vars/keepalived3.yml
+++ b/tests/host_vars/keepalived3.yml
@@ -1,0 +1,2 @@
+---
+keepalived_ubuntu_src: uca

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -29,5 +29,5 @@ keepalived_uca_repo_dist: "{{ ansible_lsb.codename }}-updates/{{ keepalived_uca_
 keepalived_uca_openstack_release: ocata
 
 ## Prevent start on install
-prevent_start_file: "/usr/sbin/policy-rc.d"
-prevent_start_file_content: "exit 101"
+prevent_start_file: "/etc/systemd/system/keepalived.service"
+prevent_start_file_content: false


### PR DESCRIPTION
the PR #53 has demonstrated an issue of coverage: The Vagrant test was only caring about ppa, and not uca, which should be technically the same.

However, the ppa now ships with different files (systemd units/sample files) causing discrependencies with different deploy methods.

This PR adds testing and adds, at the same time, the needed work of PR #53 .