### PR TITLE
Add keepalived_global_defs configuration directive

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -49,3 +49,7 @@ cache_timeout: 600
 keepalived_instances: []
 keepalived_sync_groups: {}
 keepalived_bind_on_non_local: False
+
+# This list of strings will appear in the global_defs section of the
+# keepalived configuration file.
+keepalived_global_defs: []

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -52,4 +52,6 @@ keepalived_bind_on_non_local: False
 
 # This list of strings will appear in the global_defs section of the
 # keepalived configuration file.
-keepalived_global_defs: []
+# Example:
+#keepalived_global_defs:
+#  - enable_script_security

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -13,6 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+{% if keepalived_global_defs is defined %}
+global_defs {
+{% for def in keepalived_global_defs %}
+  {{ def }}
+{% endfor %}
+}
+{% endif %}
+
 {% for name, sync_group in keepalived_sync_groups.items() %}
 vrrp_sync_group {{ name }} {
   group {


### PR DESCRIPTION
When `enable_script_security` is not present in keepalived.conf,
the daemon will print a warning in the journal:

    SECURITY VIOLATION - scripts are being executed but
    script_security not enabled.

This patch enables script security which ensures that a non-root
user cannot maliciously alter a script that keepalived may be running
as root.

This fixes Launchpad bug 1742487:

  https://bugs.launchpad.net/openstack-ansible/+bug/1742487