### PR TITLE
Add Debian Stretch support

### DIFF
--- a/Vagrantfile
+++ b/Vagrantfile
@@ -6,23 +6,28 @@ ANSIBLE_RAW_SSH_ARGS = []
 boxes = [
     {
         :name => "keepalived1",
-        :eth1 => "192.168.33.10",
+        :eth1 => "192.168.33.11",
         :image => "ubuntu/trusty64",
     },
     {
         :name => "keepalived2",
-        :eth1 => "192.168.33.11",
-        :image => "ubuntu/xenial64",
-    },
-    {
-        :name => "keepalived3",
         :eth1 => "192.168.33.12",
         :image => "ubuntu/xenial64",
     },
     {
-        :name => "keepalived4",
+        :name => "keepalived3",
         :eth1 => "192.168.33.13",
+        :image => "ubuntu/xenial64",
+    },
+    {
+        :name => "keepalived4",
+        :eth1 => "192.168.33.14",
         :image => "centos/7",
+    },
+    {
+        :name => "keepalived5",
+        :eth1 => "192.168.33.15",
+        :image => "debian/stretch64",
     }
 ]
 
@@ -56,7 +61,7 @@ Vagrant.configure(2) do |config|
       # Vagrant works serially and provision machines
       # serially. Each of them is unaware of the others.
       # Therefore, we should start provisioning only on last machine
-      if boxopts[:name] == "keepalived4"
+      if boxopts[:name] == "keepalived5"
         config.vm.provision :ansible do |ansible|
           ansible.playbook = "tests/deploy.yml"
           ansible.extra_vars = "tests/keepalived_haproxy_combined_example.yml"

--- a/tests/deploy.yml
+++ b/tests/deploy.yml
@@ -4,7 +4,7 @@
   gather_facts: no
   tasks:
     - name: Install python2
-      raw: sudo apt-get update && sudo apt install -y python; sudo locale-gen en_GB.UTF-8
+      raw: sudo apt-get update && sudo apt install -y python python-apt; sudo locale-gen en_GB.UTF-8
       changed_when: false
 
 - hosts: all
@@ -45,17 +45,8 @@
   become: true
   become_method: sudo
   tasks:
-    - shell: ifconfig {{ vrrp_nic }} down || true
-      changed_when: false
-      when: inventory_hostname != ansible_play_hosts[-1]
-    - name: The VRRP state needs to adapt the topo change
-      wait_for:
-        timeout: 12
-    - setup:
-        gather_subset: network
-    - debug:
-        var: ansible_all_ipv4_addresses
-    - assert:
-        that:
-          - "'192.168.33.2' in ansible_all_ipv4_addresses"
-      when: inventory_hostname == ansible_play_hosts[-1]
+    - name: Do functional tests for each server
+      include: functional-test.yml
+      with_items: "{{ ansible_play_hosts[2:] }}"
+      loop_control:
+        loop_var: master_hostname

--- a/tests/functional-test.yml
+++ b/tests/functional-test.yml
@@ -1,0 +1,23 @@
+---
+- name: Testing failover on {{ master_hostname }}
+  debug:
+    var: master_hostname
+    verbosity: 3
+- name: Bringing the interface down
+  shell: ifconfig {{ vrrp_nic }} down || ip link set {{ vrrp_nic }} down || true
+  changed_when: false
+  when: inventory_hostname != master_hostname
+- name: The VRRP state needs to adapt the topo change
+  wait_for:
+    timeout: 5
+- setup:
+    gather_subset: network
+- debug:
+    var: ansible_all_ipv4_addresses
+- assert:
+    that:
+      - "'192.168.33.2' in ansible_all_ipv4_addresses"
+  when: inventory_hostname == master_hostname
+- name: Ensure all vrrp nics are up
+  shell: ip link set dev {{ vrrp_nic }} up || true
+  changed_when: false

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -13,25 +13,13 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-galaxy_info:
-  author: Jean-Philippe Evrard
-  description:  This role installs and configure keepalived based on a variable file
-  license: Apache
-  min_ansible_version: 2.3
-  platforms:
-  - name: EL
-    versions:
-    - 7
-  - name: Ubuntu
-    versions:
-    - trusty
-    - xenial
-  - name: opensuse
-    versions:
-    - all
-  - name: debian
-    versions:
-    - stretch
-  categories:
-  - clustering
-dependencies: []
+#Standard names and paths for ubuntu 16.04
+keepalived_package_name: "keepalived"
+keepalived_service_name: "keepalived"
+keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+# Debian is WIP, and only native packages from the distribution are supported for now.
+keepalived_ubuntu_src: "native" #no support of ppas under debian -> forced source to be native
+
+## Prevent start on install
+prevent_start_file: "/etc/systemd/system/keepalived.service"
+prevent_start_file_content: false


### PR DESCRIPTION
Requested by @rlex.
A few remarks:
- python-apt isn't present in the vagrant image, so we install it
- this has caught an issue with the testing: some images don't
  have ifconfig anymore
- this also adds functional testing of more nodes now, not
  only the last one.