### PR TITLE
Do not imply python-apt is installed

### DIFF
--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -45,6 +45,15 @@
   tags:
     - keepalived-repo
 
+- name: Ensure python apt is installed
+  apt:
+    name: python-apt
+    state: present
+  when:
+    - ansible_pkg_mgr == 'apt'
+  tags:
+    - keepalived-apt-packages
+
 - name: Check if keepalived is already installed
   package:
     name: "{{ keepalived_package_name }}"


### PR DESCRIPTION
If an apt task is used with check mode and python-apt isn't
installed, the task will fail. Technically the package python-apt
is installed during module execution when not running check-mode,
so it makes sense to add it before running check mode to avoid
implicit dependencies.