### PR TITLE
Added ability to specify daemon launch arguments.

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -55,3 +55,8 @@ keepalived_bind_on_non_local: False
 # Example:
 #keepalived_global_defs:
 #  - enable_script_security
+
+# Set keepalived daemon extra arguments.
+# Example:
+#keepalived_extra_args: ["snmp"]
+keepalived_extra_args: []

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -45,10 +45,21 @@
   tags:
     - keepalived-install
 
-- name: configure keepalived
+- name: Configure keepalived
   template:
     src: keepalived.conf.j2
     dest: "{{ keepalived_config_file_path }}"
+  tags:
+    - keepalived-config
+  notify:
+    - restart keepalived
+
+- name: Setting keepalived extra args
+  lineinfile:
+    line: '{{ keepalived_daemon_options_variable }}="{% if keepalived_extra_args|length > 0 %}{% for arg in keepalived_extra_args %} --{{ arg }}{% endfor %}{% endif %}"'
+    regexp: "^{{ keepalived_daemon_options_variable }}"
+    path: "{{ keepalived_daemon_options_file_path }}"
+    state: present
   tags:
     - keepalived-config
   notify:

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -17,6 +17,8 @@
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_daemon_options_file_path: "/etc/default/keepalived"
+keepalived_daemon_options_variable: "DAEMON_ARGS"
 # Debian is WIP, and only native packages from the distribution are supported for now.
 keepalived_ubuntu_src: "native" #no support of ppas under debian -> forced source to be native
 

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -17,3 +17,5 @@
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
+keepalived_daemon_options_variable: "KEEPALIVED_OPTIONS"

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -16,3 +16,5 @@
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
+keepalived_daemon_options_variable: "KEEPALIVED_OPTIONS"

--- a/vars/ubuntu-14.04.yml
+++ b/vars/ubuntu-14.04.yml
@@ -17,6 +17,8 @@
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_daemon_options_file_path: "/etc/default/keepalived"
+keepalived_daemon_options_variable: "DAEMON_ARGS"
 
 ## Repo details for keepalived ppa
 keepalived_ppa_repo: "ppa:keepalived/stable"

--- a/vars/ubuntu-16.04.yml
+++ b/vars/ubuntu-16.04.yml
@@ -17,6 +17,8 @@
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived.service"
 keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_daemon_options_file_path: "/etc/default/keepalived"
+keepalived_daemon_options_variable: "DAEMON_ARGS"
 
 ## Repo details for keepalived ppa
 keepalived_ppa_repo: "ppa:keepalived/stable"


### PR DESCRIPTION
It may be used for providing extra args for keepalived daemon.
With these args it's possible to change logging options or enabling SNMP checks.