### PR TITLE
Deprecation fixes

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -17,7 +17,7 @@ galaxy_info:
   author: Jean-Philippe Evrard
   description:  This role installs and configure keepalived based on a variable file
   license: Apache
-  min_ansible_version: 2.3
+  min_ansible_version: 2.4
   platforms:
   - name: EL
     versions:

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -67,7 +67,7 @@
     content: "{{ prevent_start_file_content }}"
   when:
     - ansible_os_family | lower == 'debian'
-    - check_if_present | changed
+    - check_if_present is changed
     - ansible_service_mgr is defined
     - ansible_service_mgr != 'systemd'
   tags:
@@ -80,7 +80,7 @@
     dest: "{{ prevent_start_file }}"
   when:
     - ansible_os_family | lower == 'debian'
-    - check_if_present | changed
+    - check_if_present is changed
     - ansible_service_mgr is defined
     - ansible_service_mgr == 'systemd'
   tags:
@@ -99,7 +99,7 @@
   file:
     path: /etc/keepalived/samples/
     state: absent
-  when: 
+  when:
     - ansible_os_family | lower == 'debian'
 
 - name: Revert keepalived start prevention
@@ -108,13 +108,13 @@
     state: absent
   when:
     - ansible_os_family | lower == 'debian'
-    - check_if_present | changed
+    - check_if_present is changed
   tags:
     - keepalived-prevent-start
 
 - name: "Systemd daemon_reload"
   command: systemctl daemon-reload
-  changed_when: check_if_present | changed
+  changed_when: check_if_present is changed
   when:
     - ansible_service_mgr is defined
     - ansible_service_mgr == 'systemd'

--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -20,13 +20,12 @@
 
 - name: Ensure SELinux packages are installed
   yum:
-    name: "{{ item }}"
+    name:
+      - libselinux
+      - libselinux-devel
+      - checkpolicy
+      - policycoreutils-python
     state: present
-  with_items:
-    - libselinux
-    - libselinux-devel
-    - checkpolicy
-    - policycoreutils-python
   when:
     - '"keepalived_ping" not in selinux_modules.stdout'
 


### PR DESCRIPTION
Hello! This PR:

1) Will fix "Using tests as filters is deprecated"
2) Will fix "Invoking "yum" only once while using a loop via squash_actions is deprecated"

All changes are internal, so there is no functional/syntax changes.