### PR TITLE
Extend realservers check configuration

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -145,6 +145,14 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
 
   {% for rserver in vserver.real_servers %}
   real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% if rserver.tcp_checks is defined %}
+    {% for tcp_check in rserver.tcp_checks %}
+    TCP_CHECK {
+      connect_port "{{ tcp_check.connect_port }}"
+      connect_timeout "{{ tcp_check.connect_timeout }}"
+    }
+    {% endfor %}
+    {% endif %}
     {% if rserver.misc_check is defined %}
     {% for mcheck in rserver.misc_check %}
     MISC_CHECK {

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -148,8 +148,8 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
     {% if rserver.tcp_checks is defined %}
     {% for tcp_check in rserver.tcp_checks %}
     TCP_CHECK {
-      connect_port "{{ tcp_check.connect_port }}"
-      connect_timeout "{{ tcp_check.connect_timeout | default('5') }}"
+      connect_port {{ tcp_check.connect_port }}
+      connect_timeout {{ tcp_check.connect_timeout | default('5') }}
     }
     {% endfor %}
     {% endif %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -149,7 +149,7 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
     {% for tcp_check in rserver.tcp_checks %}
     TCP_CHECK {
       connect_port "{{ tcp_check.connect_port }}"
-      connect_timeout "{{ tcp_check.connect_timeout }}"
+      connect_timeout "{{ tcp_check.connect_timeout | default('5') }}"
     }
     {% endfor %}
     {% endif %}


### PR DESCRIPTION
Make it possible to use `TCP_CHECK`s in the keepalived configuration.