### PR TITLE
Add ability to have src_check_script and check_script with parameters

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -77,7 +77,7 @@
 - name: Dropping the tracking scripts
   copy:
     src: "{{ item.value.src_check_script }}"
-    dest: "{{ item.value.check_script }}"
+    dest: "{{ item.value.dest_check_script|default(item.value.check_script) }}"
     mode: "0755"
   with_dict: "{{ keepalived_scripts | default('{}') }}"
   when: item.value.src_check_script is defined


### PR DESCRIPTION
If we just use "check_script" and "src_check_script",
the file from the source will be copy, to the target,
and take the name set on "check_script". This could be
an issue if we have parameters under "check_script".
For example, if we have something like:
check_script: "/etc/keepalived/pingable_check.sh
{{ keepalived_ping_count }} {{ keepalived_ping_address }}"

We could end up with a file name:
"/etc/keepalived/pingable_check.sh 1 203.0.113.89"

We should for that have an optional field for setting
the destination without taking the parameters,
like dest_check_script.