### PR TITLE
Add ssl_get check

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -167,6 +167,19 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
     }
     {% endfor %}
     {% endif %}
+    {% if rserver.ssl_get is defined %}
+    {% for sslcheck in rserver.ssl_get %}
+    SSL_GET {
+      url {
+        path {{ sslcheck.url_path }}
+        digest {{ sslcheck.url_digest }} 
+      }
+      connect_timeout {{ sslcheck.connect_timeout | default('3') }}
+      nb_get_retry {{ sslcheck.nb_get_retry | default('3') }}
+      delay_before_retry {{ sslcheck.delay_before_retry | default('2') }}
+    }
+    {% endfor %}
+    {% endif %}
   }
   {% endfor %}
 

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -128,3 +128,11 @@ keepalived_instances:
 #              warmup: true
 #              # Optinal, set false or omit to not use it.
 #              misc_dynamic: true
+#        ssl_get:
+#          - url_path: '/'
+#            url_digest: 'a797b47875d8fd5c949066182902099d'
+#            # Optional
+#            connect_timeout: 3
+#            nb_get_retry: 3
+#            delay_before_retry: 2
+


### PR DESCRIPTION
Add the SSL_GET section for real_servers, as described in
https://manpages.debian.org/stretch/keepalived/keepalived.conf.5.en.html
Search for "SSL_GET"