### PR TITLE
Update testing timeouts


### DIFF
--- a/tests/functional-test.yml
+++ b/tests/functional-test.yml
@@ -1,18 +1,18 @@
 ---
 - name: Ensure all vrrp nics are up
-  shell: ip link set dev {{ vrrp_nic }} up || ifconfig {{ vrrp_nic }} up || true
+  shell: ip link set dev {{ vrrp_nic }} up || ifconfig {{ vrrp_nic }} up
   changed_when: false
 - name: Testing failover on {{ master_hostname }}
   debug:
     var: master_hostname
     verbosity: 3
 - name: Bringing the interfaces down
-  shell: ip link set {{ vrrp_nic }} down || ifconfig {{ vrrp_nic }} down || true
+  shell: ip link set {{ vrrp_nic }} down || ifconfig {{ vrrp_nic }} down
   changed_when: false
   when: inventory_hostname != master_hostname
 - name: The VRRP state needs to adapt the topo change
   wait_for:
-    timeout: 5
+    timeout: 8
 - setup:
     gather_subset: network
 - debug:


### PR DESCRIPTION


The testing is waiting for keepalived to be back up in 5 seconds.
In my new environment, this lead to transient failures, as it's
not running on nvme anymore, and my hardware is now also far
slower cpu wise.

This increases the timeouts to make sure things are more reliable.

