### PR TITLE
SELinux fixes (check mode)

### DIFF
--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -17,6 +17,7 @@
   command: semodule -l
   changed_when: False
   register: selinux_modules
+  check_mode: no
 
 - name: Ensure SELinux packages are installed
   yum:

--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -31,6 +31,8 @@
     - '"keepalived_ping" not in selinux_modules.stdout'
 
 - include: keepalived_selinux_compile.yml
+  when:
+    - selinux_policy_name not in selinux_modules.stdout
   with_items: "{{ keepalived_selinux_compile_rules }}"
   loop_control:
     loop_var: selinux_policy_name

--- a/tasks/keepalived_selinux_compile.yml
+++ b/tasks/keepalived_selinux_compile.yml
@@ -18,8 +18,6 @@
     path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
     state: directory
     mode: '0755'
-  when:
-    - selinux_policy_name not in selinux_modules.stdout
 
 - name: Deploy SELinux policy source file
   copy:
@@ -28,8 +26,6 @@
     owner: root
     group: root
     mode: "0755"
-  when:
-    - selinux_policy_name not in selinux_modules.stdout
 
 - name: Compile and load SELinux module
   command: "{{ item }}"
@@ -40,12 +36,8 @@
     - checkmodule -M -m -o {{ selinux_policy_name }}.mod {{ selinux_policy_name }}.te
     - semodule_package -o {{ selinux_policy_name }}.pp -m {{ selinux_policy_name }}.mod
     - semodule -i {{ selinux_policy_name }}.pp
-  when:
-    - selinux_policy_name not in selinux_modules.stdout
 
 - name: Remove temporary directory
   file:
     path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
     state: absent
-  when:
-    - selinux_policy_name not in selinux_modules.stdout

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -30,6 +30,7 @@
 
 - include: keepalived_selinux.yml
   when:
+    - keepalived_selinux_compile_rules | length > 0
     - ansible_selinux.status is defined
     - ansible_selinux.status == "enabled"
   tags:


### PR DESCRIPTION
Currently in check mode (--check) role fails with error:

> The conditional check 'selinux_policy_name not in selinux_modules.stdout' failed. The error was: error while evaluating conditional (selinux_policy_name not in selinux_modules.stdout): Unable to look up a name or access an attribute in template string ({% if selinux_policy_name not in selinux_modules.stdout %} True {% else %} False {% endif %}).
> Make sure your variable name does not contain invalid characters like '-': argument of type 'StrictUndefined' is not iterable

These commits prevent such error and installing SELinux-related packages when list `keepalived_selinux_compile_rules` is empty.