### PR TITLE
Do not pass the copyright notice to the generated file

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -1,4 +1,5 @@
 #jinja2: lstrip_blocks: True
+{#
 # Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,6 +13,7 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+-#}
 
 {% if keepalived_global_defs is defined %}
 global_defs {


### PR DESCRIPTION
While the template itself is copyright-protected, I would not consider the generated config file a Derivative Work, therefore (as far as I know) it should not contain the Apache license template.