### PR TITLE
Allow not to create overrides for keepalived.service (systemd)

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -56,6 +56,11 @@ keepalived_bind_on_non_local: False
 #keepalived_global_defs:
 #  - enable_script_security
 
+# Whether to add systemd overrides for keepalived:
+# Wants=network-online.target
+# After=network-online.target
+keepalived_systemd_overrides: True
+
 # Set location of keepalived daemon options file path
 # For Debian based systems it's usually /etc/default/keepalived
 # For RedHat based systems it's usually /etc/sysconfig/keepalived

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -206,7 +206,9 @@
   file:
     path: /etc/systemd/system/keepalived.service.d/
     state: directory
-  when: ansible_service_mgr == 'systemd'
+  when:
+    - ansible_service_mgr == 'systemd'
+    - keepalived_systemd_overrides | bool
 
 - name: Apply keepalived override to start after network is up
   ini_file:
@@ -219,4 +221,14 @@
   with_items:
     - 'Wants'
     - 'After'
-  when: ansible_service_mgr == 'systemd'
+  when:
+    - ansible_service_mgr == 'systemd'
+    - keepalived_systemd_overrides | bool
+
+- name: Remove keepalived overrides
+  file:
+    path: /etc/systemd/system/keepalived.service.d/override.conf
+    state: absent
+  when:
+    - ansible_service_mgr == 'systemd'
+    - not (keepalived_systemd_overrides | bool)


### PR DESCRIPTION
Some operating systems may have proper settings already - i.e. CentOS 7+