### PR TITLE
add advert_int, weight and thresholds

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -84,7 +84,7 @@ vrrp_instance {{ name }} {
   {% if instance.preempt_delay is defined %}
   preempt_delay {{ instance.preempt_delay }}       # Seconds after startup until preemption. 0 (default) to 1,000.
   {% endif %}
-  {% if instance.advert_int is defined and instance.advert_int | int %}
+  {% if instance.advert_int is defined %}
   advert_int {{ instance.advert_int }}
   {% endif %}
   {% if instance.authentication_password is defined %}
@@ -170,14 +170,14 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
 
   {% for rserver in vserver.real_servers %}
   real_server {{ rserver.ip }} {{ rserver.port }} {
-    {% if rserver.weight is defined and rserver.weight | int %}
-    weight {{ rserver.weight }}
+    {% if rserver.weight is defined %}
+    weight {{ rserver.weight | int }}
     {% endif %}
-    {% if rserver.uthreshold is defined and rserver.uthreshold | int %}
-    uthreshold {{ rserver.uthreshold }}
+    {% if rserver.uthreshold is defined %}
+    uthreshold {{ rserver.uthreshold | int }}
     {% endif %}
-    {% if rserver.lthreshold is defined and rserver.lthreshold | int %}
-    lthreshold {{ rserver.lthreshold }}
+    {% if rserver.lthreshold is defined %}
+    lthreshold {{ rserver.lthreshold | int }}
     {% endif %}
     {% if rserver.tcp_checks is defined %}
     {% for tcp_check in rserver.tcp_checks %}

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -84,6 +84,9 @@ vrrp_instance {{ name }} {
   {% if instance.preempt_delay is defined %}
   preempt_delay {{ instance.preempt_delay }}       # Seconds after startup until preemption. 0 (default) to 1,000.
   {% endif %}
+  {% if instance.advert_int is defined and instance.advert_int | int %}
+  advert_int {{ instance.advert_int }}
+  {% endif %}
   {% if instance.authentication_password is defined %}
   authentication {
     auth_type PASS

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -167,6 +167,15 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
 
   {% for rserver in vserver.real_servers %}
   real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% if rserver.weight is defined and rserver.weight | int %}
+    weight {{ rserver.weight }}
+    {% endif %}
+    {% if rserver.uthreshold is defined and rserver.uthreshold | int %}
+    uthreshold {{ rserver.uthreshold }}
+    {% endif %}
+    {% if rserver.lthreshold is defined and rserver.lthreshold | int %}
+    lthreshold {{ rserver.lthreshold }}
+    {% endif %}
     {% if rserver.tcp_checks is defined %}
     {% for tcp_check in rserver.tcp_checks %}
     TCP_CHECK {
@@ -208,7 +217,7 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
       misc_dynamic
       {% endif %}
       {% if mcheck.user is defined and mcheck.user %}
-      {% if mcheck.group is defined and mcheck.group %} 
+      {% if mcheck.group is defined and mcheck.group %}
       user {{ mcheck.user }} {{ mcheck.group }}
       {% else %}
       user {{ mcheck.user }}
@@ -223,7 +232,7 @@ virtual_server {{ vserver.ip }} {{ vserver.port }} {
       url {
         path {{ http_check.url_path }}
         digest {{ http_check.url_digest }}
-      } 
+      }
       connect_timeout {{ http_check.connect_timeout | default('3') }}
       nb_get_retry {{ http_check.nb_get_retry | default('3') }}
       delay_before_retry {{ http_check.delay_before_retry | default('2') }}

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -114,7 +114,13 @@ keepalived_instances:
 #    real_servers:
 #      - IP: '8.8.8.8'
 #        port: '53'
-#        # Currently on MISC_CHECK is supported. Section is optional.
+#        # Optional, relative weight to use, default: 1
+#        weight: 3
+#        # Optional, maximum number of connections to server
+#        uthreshold: 1000
+#        # Optional, minimum number of connections to server
+#        lthreshold: 1000
+#        # Section is optional.
 #        misc_check:
 #            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
 #              # Role default is 3

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -66,6 +66,8 @@ keepalived_instances:
     state: MASTER
     virtual_router_id: 10
     priority: 100
+    #Optional, VRRP Advert interval in seconds 
+    #advert_int: 1
     # Please set this if you want to use authentication in your VRRP
     # instance. If more than 8 characters, it will be truncated.
     # The password must be the same per router_id (so backup and


### PR DESCRIPTION
Hello again,

some smaller additions. 
- vrrp advert_int 
- real_server weight
- real_server uthreshold
- real_server lthreshold

another pull request will follow, because I would like to add `virtual_server_group` 
> This feature offers a way to simplify your configuration by factorizing virtual server
> definitions. If you need to define a bunch of virtual servers with exactly the same
> real server topology then this feature will make your configuration much more readable
> and will optimize healthchecking task by only spawning one healthchecking where
> multiple virtual server declaration will spawn a dedicated healthchecker for every
> real server which will waste system resources.

that would include a split up of the current `keepalived.conf.j2` template to reduce duplicate code without breaking the backward compatibility

Regards