### PR TITLE
Add optional virtual_ipaddress_excluded section

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -106,6 +106,13 @@ vrrp_instance {{ name }} {
     {{ vip }}
     {% endfor %}
   }
+  {% if instance.vips_excluded is defined %}
+  virtual_ipaddress_excluded {
+    {% for vip in instance.vips_excluded %}
+    {{ vip }}
+    {% endfor %}
+  }
+  {% endif %}
   {% if instance.virtual_routes is defined %}
   virtual_routes {
   {% for route in instance.virtual_routes %}

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -83,6 +83,9 @@ keepalived_instances:
     #track_interfaces:
     #  - eth1
     #  - eth2
+    # Optional virtual_ipaddress_excluded section
+    #vips_excluded:
+    #  - "10.0.0.1 dev eth0"
   internal:
     interface: eth1
     state: MASTER


### PR DESCRIPTION
Keepalived has a feature to include IP addresses that keepalived
should bring up and down, but not include in VRRP packets.