### PR TITLE
Remove install python-apt task: trust target is properly set up for ansible.

### DIFF
--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -45,9 +45,9 @@
   tags:
     - keepalived-repo
 
-- name: Ensure python apt is installed
+- name: Ensure python-apt or python3-apt is installed
   apt:
-    name: python-apt
+    name: "python{{ ansible_python_interpreter | default('') | regex_search('3$') }}-apt"
     state: present
   when:
     - ansible_pkg_mgr == 'apt'


### PR DESCRIPTION
based on ansible_python_interpreter of target