### PR TITLE
Fix "file was found when using first_found"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -16,11 +16,15 @@
 - name: Gather variables for each operating system
   include_vars: "{{ item }}"
   with_first_found:
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
-    - "{{ ansible_distribution | lower }}.yml"
-    - "{{ ansible_os_family | lower }}.yml"
+    - files:
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
+      - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+      - "{{ ansible_os_family | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
+      - "{{ ansible_distribution | lower }}.yml"
+      - "{{ ansible_os_family | lower }}.yml"
+    - paths:
+      - "{{ role_path }}/vars"
+      skip: true
   tags:
     - always
 


### PR DESCRIPTION
When the role is used alongside some other tasks in a playbook, Ansible tries to include the OS vars but cannot find them.

Let's assume, our playbook is built as follows:
```yaml
- hosts: haproxy
  tags: keepalived
  become: yes
  roles:
    - { role: keepalived }

- hosts: all
  tags: some-other-tasks
  become: yes
  tasks:
    - debug: msg=test
```

The role resides in the directory `roles/haproxy`. However, the following error occurs with the current implementation:
```
No file was found when using first_found. Use errors='ignore' to allow this task to be skipped if no files are found
```
Due to the `always` flag, this is the case even when the role should not be executed in the first place.

As a workaround, one can define the "some-other-tasks" in a separate playbook. This solution works, but I propose to improve the role in a way that you can use it alongside "some-other-tasks" unrelated to keepalived. 

With the fix from this PR, Ansible always finds the correct files on the path `{{ role_path }}/vars"` and continues with an empty file list (skip=true) if no files are found: https://docs.ansible.com/ansible/latest/plugins/lookup/first_found.html