### PR TITLE
Ensure that keepalived is not masked

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -202,6 +202,7 @@
   service:
     name: "{{ keepalived_service_name }}"
     enabled: "yes"
+    masked: "{{ (ansible_service_mgr is defined and ansible_service_mgr == 'systemd') | ternary('no', omit) }}"
 
 - name: Make directory for keepalived's systemd overrides
   file:


### PR DESCRIPTION
In cases when keepalived is currently masked, service
enable will not work. So service will
stay in masked state and won't start with handler either.