### PR TITLE
Restart keepalived on package change

### DIFF
--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -92,6 +92,8 @@
     state: "{{ keepalived_package_state }}"
     update_cache: "{{ (ansible_pkg_mgr == 'apt') | ternary('yes', omit) }}"
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"
+  notify:
+    - restart keepalived
   tags:
     - keepalived-apt-packages
 


### PR DESCRIPTION
In case keepalived_package_state is latest it is important to restart
service in case package has been upgraded

This also adds handlers flush once role is finished.