### PR TITLE
Workaround https://github.com/ansible/ansible/pull/72337

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -17,7 +17,7 @@
 # backported to previous branches, we should rely on command to do service reload
 # else, testing is broken.
 - name: restart keepalived
-  command: "systemctl restart {{ keepalived_service_name }}"
+  shell: "systemctl restart {{ keepalived_service_name }} || service {{ keepalived_service_name }} restart"
   tags:
     - skip_ansible_lint
 #- name: restart keepalived

--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -13,8 +13,14 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Until  https://github.com/ansible/ansible/pull/72337 is solved and
+# backported to previous branches, we should rely on command to do service reload
+# else, testing is broken.
 - name: restart keepalived
-  service:
-    name: "{{ keepalived_service_name }}"
-    state: restarted
-    daemon_reload: yes
+  command: "systemctl restart {{ keepalived_service_name }}"
+  tags:
+    - skip_ansible_lint
+#- name: restart keepalived
+#  service:
+#    name: "{{ keepalived_service_name }}"
+#    state: restarted

--- a/tasks/keepalived_install.yml
+++ b/tasks/keepalived_install.yml
@@ -113,12 +113,3 @@
     - check_if_present is changed
   tags:
     - keepalived-prevent-start
-
-- name: "Systemd daemon_reload"
-  command: systemctl daemon-reload
-  changed_when: check_if_present is changed
-  when:
-    - ansible_service_mgr is defined
-    - ansible_service_mgr == 'systemd'
-  tags:
-    - skip_ansible_lint

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -270,13 +270,19 @@
 - name: Check if keepalived is enabled
   shell: "systemctl daemon-reload && systemctl is-enabled {{ keepalived_service_name }}"
   register: isenabled
-  changed_when: isenabled.stdout == "disabled" and isenabled.rc != 0
-  failed_when: isenabled.stdout != "disabled" and isenabled.rc != 0
+  changed_when: isenabled.stdout == "disabled" or isenabled.stdout == "masked"
+  failed_when: (isenabled.stdout != "disabled" or isenabled.stdout != "masked") and isenabled.rc != 0
   when: ansible_service_mgr == 'systemd'
 
+- name: Unmask keepalived if necessary
+  command: "systemctl unmask {{ keepalived_service_name }}"
+  when:
+    - isenabled is changed
+    - isenabled.stdout == "masked"
+    - ansible_service_mgr == 'systemd'
+  
 - name: ensure keepalived is enabled
   command: "systemctl enable {{ keepalived_service_name }} --now"
-  changed_when: true
   when:
     - isenabled is changed
     - ansible_service_mgr == 'systemd'

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -244,6 +244,12 @@
     - ansible_service_mgr == 'systemd'
     - not (keepalived_systemd_overrides | bool)
 
+- name: Ensuring keepalived is enabled
+  service:
+    name: "{{ keepalived_service_name }}"
+    enabled: "yes"
+  when: ansible_service_mgr != 'systemd'
+
 # Until  https://github.com/ansible/ansible/pull/72337 is fixed, we need to not use
 # the service/systemd module.
 #- name: Ensuring keepalived is enabled

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -198,12 +198,6 @@
   notify:
     - restart keepalived
 
-- name: Ensuring keepalived is enabled
-  service:
-    name: "{{ keepalived_service_name }}"
-    enabled: "yes"
-    masked: "{{ (ansible_service_mgr is defined and ansible_service_mgr == 'systemd') | ternary('no', omit) }}"
-
 - name: Make directory for keepalived's systemd overrides
   file:
     path: /etc/systemd/system/keepalived.service.d/
@@ -249,5 +243,34 @@
   when:
     - ansible_service_mgr == 'systemd'
     - not (keepalived_systemd_overrides | bool)
-  notify:
-    - restart keepalived
+
+# Until  https://github.com/ansible/ansible/pull/72337 is fixed, we need to not use
+# the service/systemd module.
+#- name: Ensuring keepalived is enabled
+#  service:
+#    name: "{{ keepalived_service_name }}"
+#    enabled: "yes"
+#    masked: "{{ (ansible_service_mgr is defined and ansible_service_mgr == 'systemd') | ternary('no', omit) }}"
+#
+
+# Reload systemd is necessary if new packages, or changes of overrides.
+# Because there is no notify on those tasks, and that the notify would be happening after the
+# task to ensure keepalived is enabled, move it to an unconditional task here.
+# When the bug above is fixed with the service/systemd module, ensure everything is
+# done in a single handler, tackling the daemon-reloads and the restart of the service,
+# plus a single task, handling the daemon-reload and ensuring the service is enabled
+# on the first install (the changes in systemd files would have to trigger the
+# handler to restart the service).
+- name: Check if keepalived is enabled
+  shell: "systemctl daemon-reload && systemctl is-enabled {{ keepalived_service_name }}"
+  register: isenabled
+  changed_when: isenabled.stdout == "disabled" and isenabled.rc != 0
+  failed_when: isenabled.stdout != "disabled" and isenabled.rc != 0
+  when: ansible_service_mgr == 'systemd'
+
+- name: ensure keepalived is enabled
+  command: "systemctl enable {{ keepalived_service_name }} --now"
+  changed_when: true
+  when:
+    - isenabled is changed
+    - ansible_service_mgr == 'systemd'


### PR DESCRIPTION
Without this, molecule testing and some other environments are
broken and can't install keepalived.

This should fix it until the fix above is backported to stable
Ansible branches.