### PR TITLE
feat: Add support for virtual MAC address

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -78,6 +78,9 @@ vrrp_instance {{ name }} {
   state {{ instance.state }}
   virtual_router_id {{ instance.virtual_router_id }}
   priority {{ instance.priority }}
+  {% if instance.use_vmac is defined and instance.use_vmac | bool %}
+  use_vmac                                         # Use virtual MAC address
+  {% endif %}
   {% if instance.nopreempt is defined and instance.nopreempt | bool %}
   nopreempt                                        # Override VRRP RFC preemption default
   {% endif %}

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -68,6 +68,8 @@ keepalived_instances:
     priority: 100
     #Optional, VRRP Advert interval in seconds 
     #advert_int: 1
+    # Please set this if you want to use a virtual MAC address.
+    #use_vmac: true
     # Please set this if you want to use authentication in your VRRP
     # instance. If more than 8 characters, it will be truncated.
     # The password must be the same per router_id (so backup and


### PR DESCRIPTION
I needed to configure keepalived to use a virtual MAC address. I've added it as a boolean option.

The molecule tests seem to pass. I have tested the against a couple of hosts and it worked. Please let me know if anything else is required for this to be approved. Thanks!