### PR TITLE
Add config option "notify_master_rx_lower_pri"

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -130,6 +130,18 @@
   notify:
     - reload keepalived
 
+- name: Dropping the notification scripts for lower priority master case
+  copy:
+    src: "{{ item.value.src_notify_master_rx_lower_pri }}"
+    dest: "{{ item.value.notify_master_rx_lower_pri }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_sync_groups }}"
+  when: item.value.src_notify_master_rx_lower_pri is defined
+  tags:
+    - keepalived-config
+  notify:
+    - reload keepalived
+
 - name: Dropping the notification scripts for switching to backup
   copy:
     src: "{{ item.value.src_notify_backup }}"
@@ -173,6 +185,18 @@
     mode: "0755"
   with_dict: "{{ keepalived_instances }}"
   when: item.value.src_notify_master is defined
+  tags:
+    - keepalived-config
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for lower priority master case (instances)
+  copy:
+    src: "{{ item.value.src_notify_master_rx_lower_pri }}"
+    dest: "{{ item.value.notify_master_rx_lower_pri }}"
+    mode: "0755"
+  with_dict: "{{ keepalived_instances }}"
+  when: item.value.src_notify_master_rx_lower_pri is defined
   tags:
     - keepalived-config
   notify:

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -36,6 +36,9 @@ vrrp_sync_group {{ name }} {
   {% if sync_group.notify_master is defined %}
   notify_master "{{ sync_group.notify_master }}"
   {% endif %}
+  {% if sync_group.notify_master_rx_lower_pri is defined %}
+  notify_master_rx_lower_pri "{{ sync_group.notify_master_rx_lower_pri }}"
+  {% endif %}
   {% if sync_group.notify_backup is defined %}
   notify_backup "{{ sync_group.notify_backup }}"
   {% endif %}
@@ -154,6 +157,9 @@ vrrp_instance {{ name }} {
   {% endif %}
   {% if instance.notify_master is defined %}
   notify_master "{{ instance.notify_master }}"
+  {% endif %}
+  {% if instance.notify_master_rx_lower_pri is defined %}
+  notify_master_rx_lower_pri "{{ instance.notify_master_rx_lower_pri }}"
   {% endif %}
   {% if instance.notify_backup is defined %}
   notify_backup "{{ instance.notify_backup }}"

--- a/tests/keepalived_haproxy_backup_example.yml
+++ b/tests/keepalived_haproxy_backup_example.yml
@@ -34,6 +34,8 @@ keepalived_sync_groups:
     # Their deployment and configuration are like the notify_script
     #notify_master:
     #src_notify_master:
+    #notify_master_rx_lower_pri:
+    #src_notify_master_rx_lower_pri:
     #notify_backup:
     #src_notify_backup:
     #notify_fault:

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -34,6 +34,8 @@ keepalived_sync_groups:
     # Their deployment and configuration are like the notify_script
     #notify_master:
     #src_notify_master:
+    #notify_master_rx_lower_pri:
+    #src_notify_master_rx_lower_pri:
     #notify_backup:
     #src_notify_backup:
     #notify_fault:
@@ -66,7 +68,7 @@ keepalived_instances:
     state: MASTER
     virtual_router_id: 10
     priority: 100
-    #Optional, VRRP Advert interval in seconds 
+    #Optional, VRRP Advert interval in seconds
     #advert_int: 1
     # Please set this if you want to use a virtual MAC address.
     #use_vmac: true
@@ -165,7 +167,7 @@ keepalived_instances:
 #            bindto: '10.0.0.2'
 #            # Optional, fwmark to mark all outgoing checker packets with
 #            fwmark: 2
-#            # Optional, random delay to start the initial check    
+#            # Optional, random delay to start the initial check
 #            warmup: 2
 #        http_get:
 #          - url_path: '/'
@@ -182,7 +184,7 @@ keepalived_instances:
 #            bindto: '10.0.0.2'
 #            # Optional, Optional fwmark to mark all outgoing checker packets with
 #            fwmark: 2
-#            # Optional random delay to start the initial check    
+#            # Optional random delay to start the initial check
 #            warmup: 2
 #        tcp_checks:
 #            #Port to connect to
@@ -199,7 +201,7 @@ keepalived_instances:
 #            bindto: '10.0.0.2'
 #            # Optional, fwmark to mark all outgoing checker packets with
 #            fwmark: 2
-#            # Optional, random delay to start the initial check    
+#            # Optional, random delay to start the initial check
 #            warmup: 2
 #        dns_checks:
 #            # IP to connect to
@@ -221,7 +223,7 @@ keepalived_instances:
 #
 #
 # # Define Keepalived Virtual Server Groups
-# 
+#
 #keepalived_virtual_server_groups:
 #  - name: server_group_1
 #    # Multiple VIPs (configured in keepalived_instances) are allowed, incl. IP Ranges


### PR DESCRIPTION
Description taken from (https://xiaoz.co/2020/09/30/keepalived-and-gratuitous-arp/)

```
If a lower priority router has transitioned to master, there has presumably
been an intermittent communications break between the master and backup. It
appears that servers in an Amazon AWS environment can experience this.
The problem then occurs if a notify_master script is executed on the backup
that has just transitioned to master and the script executes something like
a `aws ec2 assign-private-ip-addresses` command, thereby removing the address
from the 'proper' master. Executing notify_master_rx_lower_pri notification
allows the 'proper' master to recover the secondary addresses.
```
I had some race conditions when calling a SOAP Service Endpoint to switch the FloatingIP to the masters. With this parameter this is now solved.
