### PR TITLE
Add a conditional check to configure virtual_ipaddress

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -110,11 +110,13 @@ vrrp_instance {{ name }} {
   {% endfor %}
   }
   {% endif %}
+  {% if instance.vips is defined %}
   virtual_ipaddress {
     {% for vip in instance.vips %}
     {{ vip }}
     {% endfor %}
   }
+  {% endif %}
   {% if instance.vips_excluded is defined %}
   virtual_ipaddress_excluded {
     {% for vip in instance.vips_excluded %}


### PR DESCRIPTION
Since `virtual_ipaddress` block isn’t required by keepalived configuration, it makes sense to be able to configure an 
instance without being required to configure `instance.vips`

