### PR TITLE
Decrease TCP retries in case of VIP failover

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -31,6 +31,15 @@ keepalived_instances: {}
 keepalived_sync_groups: {}
 keepalived_bind_on_non_local: False
 
+# In case of VIP failover some applications might stuck on retrying to send
+# data without updating ARP. This variable defines amount of retries kernel
+# will send before consider connection as dead. It will influence on VIP
+# failover speed directly. Default sysctl value is 15 which result in
+# ~13 minutes of recovery. 8 retires is minimum according to RFC 1122 and
+# results in 100 seconds for timeout. Oracle suggest a value of 3 for a RAC
+# configuration which might be too agressive for some scenarios.
+keepalived_sysctl_tcp_retries: 8
+
 # This list of strings will appear in the global_defs section of the
 # keepalived configuration file.
 # Example:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -53,14 +53,18 @@
 
 - name: Allow consuming apps to bind on non local addresses
   sysctl:
-    name: "{{ item }}"
-    value: 1
+    name: "{{ item.name }}"
+    value: "{{ item.value }}"
     sysctl_set: yes
     state: present
   when: keepalived_bind_on_non_local | bool
   with_items:
-    - "net.ipv4.ip_nonlocal_bind"
-    - "net.ipv6.ip_nonlocal_bind"
+    - name: "net.ipv4.ip_nonlocal_bind"
+      value: 1
+    - name: "net.ipv6.ip_nonlocal_bind"
+      value: 1
+    - name: "net.ipv4.tcp_retries2"
+      value: "{{ keepalived_sysctl_tcp_retries }}"
   tags:
     - keepalived-install
 


### PR DESCRIPTION
In case of VIP failover some connections (like mysql) can stuck
in retrying to connect and detect a dead connection. We
should probably make this failover to be detected faster then the
default value as suggested in [1]

[1] https://access.redhat.com/solutions/726753

Related-Bug: https://bugs.launchpad.net/kolla-ansible/+bug/1917068