### PR TITLE
Remove notify_master_rx_lower_pri from sync_group

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -36,9 +36,6 @@ vrrp_sync_group {{ name }} {
   {% if sync_group.notify_master is defined %}
   notify_master "{{ sync_group.notify_master }}"
   {% endif %}
-  {% if sync_group.notify_master_rx_lower_pri is defined %}
-  notify_master_rx_lower_pri "{{ sync_group.notify_master_rx_lower_pri }}"
-  {% endif %}
   {% if sync_group.notify_backup is defined %}
   notify_backup "{{ sync_group.notify_backup }}"
   {% endif %}


### PR DESCRIPTION
There is no such thing as notify_master_rx_lower_pri for
sync_groups.

This should fix it incorrect templates.

Closes: #170 
