### PR TITLE
fix: Remove incorrect sync_group notify_master_rx_lower_pri

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -134,18 +134,6 @@
   notify:
     - reload keepalived
 
-- name: Dropping the notification scripts for lower priority master case
-  copy:
-    src: "{{ item.value.src_notify_master_rx_lower_pri }}"
-    dest: "{{ item.value.notify_master_rx_lower_pri }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_sync_groups }}"
-  when: item.value.src_notify_master_rx_lower_pri is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
 - name: Dropping the notification scripts for switching to backup
   copy:
     src: "{{ item.value.src_notify_backup }}"

--- a/tests/keepalived_haproxy_backup_example.yml
+++ b/tests/keepalived_haproxy_backup_example.yml
@@ -34,8 +34,6 @@ keepalived_sync_groups:
     # Their deployment and configuration are like the notify_script
     #notify_master:
     #src_notify_master:
-    #notify_master_rx_lower_pri:
-    #src_notify_master_rx_lower_pri:
     #notify_backup:
     #src_notify_backup:
     #notify_fault:

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -34,8 +34,6 @@ keepalived_sync_groups:
     # Their deployment and configuration are like the notify_script
     #notify_master:
     #src_notify_master:
-    #notify_master_rx_lower_pri:
-    #src_notify_master_rx_lower_pri:
     #notify_backup:
     #src_notify_backup:
     #notify_fault:


### PR DESCRIPTION
The previous patch removed the incorrect templating, but didn't
remove the scripts and the examples in the documentation.

This should fix it.
Closes: #170 
