### PR TITLE
Fix Ansible 2.9 tests

### DIFF
--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -5,6 +5,6 @@
   tasks:
   - name: Create a network with custom IPAM config
     delegate_to: localhost
-    community.general.docker_network:
+    docker_network:
       name: keepalived-network
       state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -27,7 +27,7 @@
 
   - name: Add a container to a network, leaving existing containers connected
     delegate_to: localhost
-    community.general.docker_network:
+    docker_network:
       name: keepalived-network
       connected:
         - "{{ inventory_hostname }}"

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Create a network with custom IPAM config
     delegate_to: localhost
-    community.general.docker_network:
+    docker_network:
       name: keepalived-network
       ipam_config:
         - subnet: 192.168.33.0/24

--- a/tox.ini
+++ b/tox.ini
@@ -7,7 +7,7 @@ skipsdist = true
 passenv = *
 deps =
     -rtox-requirements.txt
-    ansible-2.9: ansible<=2.10.0
+    ansible-2.9: ansible<2.10.0
     ansible-latest: ansible
 commands =
     molecule test


### PR DESCRIPTION
Without this patch, the ansible 2.9 tests can effectively install
2.10.0.

This is a problem, as it's not covering the right ansible versions.

This should fix it.