### PR TITLE
Add support for accept/no_accept for instances.

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -93,6 +93,13 @@ vrrp_instance {{ name }} {
   {% if instance.dont_track_primary is defined and instance.dont_track_primary | bool %}
   dont_track_primary                               # Override VRRP RFC dont_track_primary default
   {% endif %}
+  {% if instance.accept is defined and instance.accept | bool %}
+  {% if instance.accept %}
+  accept
+  {% else %}
+  no_accept
+  {% endif %}
+  {% endif %}
   {% if instance.authentication_password is defined %}
   authentication {
     auth_type PASS


### PR DESCRIPTION
Coming to this role wanting to implement the keepalived configuration offered by [nginx plus](https://docs.nginx.com/nginx/admin-guide/high-availability/ha-keepalived-nodes/) and they have accept inside that configuration. Had a quick dig into the manpage and thought this should suffice.