### PR TITLE
install dependencies required by keepalived scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -22,6 +22,9 @@ keepalived_selinux_compile_rules:
 #keepalived_package_state: "latest"
 keepalived_package_state: "{{ ( (keepalived_use_latest_stable | default(true)) | bool) | ternary('latest','present') }}"
 
+# Keepalived scripts may rely upon additional packages.
+keepalived_scripts_packages: []
+
 #This is the expiration time of your package manager cache.
 #When expired, this role will require to update the package manger cache.
 #This variable will be removed when the ansible upstream bugs will be fixed.

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -32,9 +32,9 @@
   tags:
     - keepalived-config
 
-- name: install keepalived
+- name: install keepalived package(s)
   package:
-    name: "{{ keepalived_package_name }}"
+    name: "{{ [keepalived_package_name] + keepalived_scripts_packages }}"
     state: "{{ keepalived_package_state }}"
     update_cache: "{{ (ansible_pkg_mgr == 'apt') | ternary('yes', omit) }}"
     cache_valid_time: "{{ (ansible_pkg_mgr == 'apt') | ternary(cache_timeout, omit) }}"


### PR DESCRIPTION
Hi,
Commands like "killall -0" are frequently used with keepalived. This PR aims to ease the installation of the packages providing those commands.