### PR TITLE
tags['always'] is bad

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -22,7 +22,10 @@
     - "{{ ansible_distribution | lower }}.yml"
     - "{{ ansible_os_family | lower }}.yml"
   tags:
-    - always
+    - keepalived-apt-packages
+    - keepalived-config
+    - keepalived-install
+    - keepalived-packages
 
 - include: keepalived_selinux.yml
   when:


### PR DESCRIPTION
Tasks with tags['always'] interfere with other roles, they are run when not asked to, which leads to this:
```
xxxx@xxxx:~/xxxx$ ansible-playbook -i inventory/ --tags etcd setup.yaml 

PLAY [elb] *******************************************************************************

TASK [evrardjp.keepalived : Gather variables for each operating system] **********************
fatal: [lb1]: FAILED! => {"msg": "No file was found when using first_found. Use errors='ignore' to allow this task to be skipped if no files are found"}
fatal: [lb2]: FAILED! => {"msg": "No file was found when using first_found. Use errors='ignore' to allow this task to be skipped if no files are found"}

PLAY RECAP ***********************************************************************************
lb1                        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
lb2                        : ok=0    changed=0    unreachable=0    failed=1    skipped=0    rescued=0    ignored=0   
```