### PR TITLE
add vmac_xmit_base support

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -81,6 +81,9 @@ vrrp_instance {{ name }} {
   {% if instance.use_vmac is defined and instance.use_vmac | bool %}
   use_vmac                                         # Use virtual MAC address
   {% endif %}
+  {% if instance.vmac_xmit_base is defined and instance.vmac_xmit_base | bool %}
+  vmac_xmit_base                                   # Use physical MAC address for communication
+  {% endif %}
   {% if instance.nopreempt is defined and instance.nopreempt | bool %}
   nopreempt                                        # Override VRRP RFC preemption default
   {% endif %}


### PR DESCRIPTION
Add support for the vmac_xmit_base option of keepalived (https://github.com/acassen/keepalived/blob/master/doc/NOTE_vrrp_vmac.txt)