### PR TITLE
fix usage of deprecated include

### DIFF
--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -26,7 +26,8 @@
   when:
     - '"keepalived_ping" not in selinux_modules.stdout'
 
-- include: keepalived_selinux_compile.yml
+- include_tasks:
+    file: keepalived_selinux_compile.yml
   when:
     - selinux_policy_name not in selinux_modules.stdout
   with_items: "{{ keepalived_selinux_compile_rules }}"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -24,7 +24,8 @@
   tags:
     - always
 
-- include: keepalived_selinux.yml
+- include_tasks:
+    file: keepalived_selinux.yml
   when:
     - keepalived_selinux_compile_rules | length > 0
     - ansible_selinux.status is defined


### PR DESCRIPTION
fixes:
`[DEPRECATION WARNING]: "include" is deprecated, use include_tasks/import_tasks instead. This feature will be removed in version 2.16.`