### PR TITLE
Remove 2.9 support

### DIFF
--- a/.github/workflows/molecule.yml
+++ b/.github/workflows/molecule.yml
@@ -7,7 +7,7 @@ jobs:
     strategy:
       max-parallel: 2
       matrix:
-        ansible: ["2.9", "latest"]
+        ansible: ["2.10", "latest"]
     steps:
       - uses: actions/checkout@v2
       - name: Install dependencies

--- a/meta/main.yml
+++ b/meta/main.yml
@@ -18,7 +18,7 @@ galaxy_info:
   author: evrardjp
   description:  This role installs and configure keepalived based on a variable file
   license: Apache
-  min_ansible_version: 2.4
+  min_ansible_version: 2.10
   platforms:
   - name: EL
     versions:

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -39,16 +39,16 @@ platforms:
     volumes:
     - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
-  - name: keepalived-rockylinux8
-    pre_build_image: yes
-    image: geerlingguy/docker-rockylinux8-ansible:latest
-    privileged: true
-    command: /sbin/init
-    tmpfs:
-      - /run
-      - /tmp
-    volumes:
-    - /sys/fs/cgroup:/sys/fs/cgroup:ro
+#  - name: keepalived-rockylinux8
+#    pre_build_image: yes
+#    image: geerlingguy/docker-rockylinux8-ansible:latest
+#    privileged: true
+#    command: /sbin/init
+#    tmpfs:
+#      - /run
+#      - /tmp
+#    volumes:
+#    - /sys/fs/cgroup:/sys/fs/cgroup:ro
 
   - name: keepalived-xenial
     pre_build_image: yes

--- a/molecule/default/molecule.yml
+++ b/molecule/default/molecule.yml
@@ -2,7 +2,7 @@
 lint: |
   set -e
   yamllint .
-  ansible-lint -vv --exclude=.tox
+  ansible-lint -v --exclude=.tox
 dependency:
   name: galaxy
 driver:

--- a/tox-requirements.txt
+++ b/tox-requirements.txt
@@ -1,4 +1,5 @@
 molecule-docker
 molecule
+molecule[docker]
 ansible-lint
 yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -1,13 +1,13 @@
 [tox]
 minversion = 1.8
-envlist = ansible-{2.9,latest}
+envlist = ansible-{2.10,latest}
 skipsdist = true
 
 [testenv]
 passenv = *
 deps =
     -rtox-requirements.txt
-    ansible-2.9: ansible<2.10.0
+    ansible-2.10: ansible==2.10
     ansible-latest: ansible
 commands =
     molecule test

--- a/tox.ini
+++ b/tox.ini
@@ -10,4 +10,5 @@ deps =
     ansible-2.10: ansible==2.10
     ansible-latest: ansible
 commands =
+    ansible-galaxy collection install community.docker
     molecule test


### PR DESCRIPTION
This makes it hard to manage, from molecule perspective:
We would need to pin to molecule-docker below 1.0.
Let's just move on with 2.10. It's time now.

Closes: #190 