### PR TITLE
Add ansible_managed output to keepalived.conf

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -13,6 +13,9 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
+# Wheter to add {{ ansible_managed }} information on top of keepalived.conf
+keepalived_show_ansible_managed: false
+
 # If running keepalived with SELinux, you could need to compile your
 # rules. Please override this list with path to files to compile.
 keepalived_selinux_compile_rules:

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -14,6 +14,11 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 -#}
+{% if keepalived_show_ansible_managed|bool %}
+#
+# {{ ansible_managed }}
+#
+{% endif %}
 
 {% if keepalived_global_defs is defined %}
 global_defs {


### PR DESCRIPTION
Output is by default enabled but can be disabled
using variable keepalived_show_ansible_managed set to false.