### PR TITLE
use reload-or-restart for service reload

### DIFF
--- a/handlers/main.yml
+++ b/handlers/main.yml
@@ -25,7 +25,7 @@
 #    name: "{{ keepalived_service_name }}"
 #    state: restarted
 - name: reload keepalived
-  command: "systemctl reload {{ keepalived_service_name }}"
+  command: "systemctl reload-or-restart {{ keepalived_service_name }}"
   tags:
     - skip_ansible_lint
 #- name: reload keepalived

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -341,7 +341,7 @@
   tags:
     - skip_ansible_lint
 
-- name: run all notified handlers to run at this point
+- name: run all notified handlers at this point
   meta: flush_handlers
 
 - name: ensure keepalived is started

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -340,3 +340,11 @@
     - isenabled is changed
   tags:
     - skip_ansible_lint
+
+- name: run all notified handlers to run at this point
+  meta: flush_handlers
+
+- name: ensure keepalived is started
+  ansible.builtin.service:
+    name: "{{ keepalived_service_name }}"
+    state: started


### PR DESCRIPTION
Use reload-or-restart for service reload, as this will start the service if it is not running.
Avoid errors if the service was stopped before the playbook run and changes in the config will trigger a reload like:
```diff
RUNNING HANDLER [keepalived : reload keepalived] ******************************************************************************************************************************************************************
! fatal: [...]: FAILED! => {"changed": true, "cmd": ["systemctl", "reload", "keepalived"], "delta": "0:00:00.006364", "end": "2022-05-02 20:45:26.891074", "msg": "non-zero return code", "rc": 1, "start": "2022-05-02 20:45:26.884710", "stderr": "keepalived.service is not active, cannot reload.", "stderr_lines": ["keepalived.service is not active, cannot reload."], "stdout": "", "stdout_lines": []} !
```