### PR TITLE
Make "auth_type" variable optional with default value

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -110,8 +110,8 @@ vrrp_instance {{ name }} {
 
   {% if instance.authentication_password is defined %}
   authentication {
-    auth_type PASS
-    auth_pass {{instance.authentication_password}}
+    auth_type {{ instance.authentication_type | default('PASS') }}
+    auth_pass {{ instance.authentication_password }}
   }
   {% endif %}
   {% if instance.unicast_src_ip is defined and instance.unicast_peers|length > 0 %}


### PR DESCRIPTION
In case if user needs to change the `auth_type` variable value to `AH`.