### PR TITLE
split keepalived config and refactoring

### DIFF
--- a/.ansible-lint
+++ b/.ansible-lint
@@ -4,4 +4,3 @@
 # Instead of renaming my role and breaking the world, I will just ignore that lint test.
 skip_list:
   - '106' # Role name {} does not match ``^[a-z][a-z0-9_]+$`` pattern
-  - 'fqcn-builtins'

--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -72,3 +72,7 @@ keepalived_daemon_options_file_path: "{{ _keepalived_daemon_options_file_path }}
 #keepalived_daemon_default_options_overrides:
 #  - "DAEMON_ARGS='--snmp'"
 keepalived_daemon_default_options_overrides: []
+
+# Remove all keepalived configurations
+# Clears entire {{ keepalived_config_directory_path }}
+keepalived_flush_configuration: False

--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -5,6 +5,6 @@
   tasks:
   - name: Create a network with custom IPAM config
     delegate_to: localhost
-    docker_network:
+    community.general.docker_network:
       name: keepalived-network
       state: absent

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -8,7 +8,7 @@
     - "100%"
   tasks:
   - name: Apt update and install rsync, ping, iproute
-    apt:
+    ansible.builtin.package:
       update_cache: yes
       name:
         - rsync
@@ -18,7 +18,7 @@
     when: ansible_os_family == "Debian"
 
   - name: Yum install iproute to fix undefined ansible_default_ipv4.address
-    yum:
+    ansible.builtin.package:
       name: iproute
       state: present
     when:
@@ -27,7 +27,7 @@
 
   - name: Add a container to a network, leaving existing containers connected
     delegate_to: localhost
-    docker_network:
+    community.general.docker_network:
       name: keepalived-network
       connected:
         - "{{ inventory_hostname }}"
@@ -38,16 +38,27 @@
       gather_subset: network
 
   - name: Show ansible_interfaces
-    debug:
+    ansible.builtin.debug:
       var: ansible_interfaces
 
   - name: Define vrrp nic
-    set_fact:
+    ansible.builtin.set_fact:
       vrrp_nic: "{{ ((ansible_interfaces | reject('equalto','lo')) | difference([ansible_default_ipv4.interface]))[0] | string }}"
 
   - name: Include keepalived vars
-    include_vars: "../../tests/keepalived_haproxy_combined_example.yml"
+    ansible.builtin.include_vars: "../../tests/keepalived_haproxy_combined_example.yml"
 
-  - name: "Include ansible-keepalived"
-    include_role:
-      name: "ansible-keepalived"
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived
+
+  - name: half way done
+    ansible.builtin.debug:
+      msg: "--- --- --- --- UPDATE CONFIGURATION --- --- --- ---" 
+
+  - name: Include keepalived edit vars
+    ansible.builtin.include_vars: "../../tests/keepalived_haproxy_combined_edit_example.yml"
+
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived

--- a/molecule/default/prepare.yml
+++ b/molecule/default/prepare.yml
@@ -4,7 +4,7 @@
   tasks:
   - name: Create a network with custom IPAM config
     delegate_to: localhost
-    docker_network:
+    community.general.docker_network:
       name: keepalived-network
       ipam_config:
         - subnet: 192.168.33.0/24

--- a/molecule/default/side_effect.yml
+++ b/molecule/default/side_effect.yml
@@ -6,39 +6,39 @@
     vrrp_ip: 192.168.33.2
   tasks:
     - name: Define vrrp nic
-      set_fact:
+      ansible.builtin.set_fact:
         vrrp_nic: "{{ ((ansible_interfaces | reject('equalto','lo')) | difference([ansible_default_ipv4.interface]))[0] | string }}"
 
     - name: Disable current master node
-      command: ip link set dev {{ vrrp_nic }} down
+      ansible.builtin.command: ip link set dev {{ vrrp_nic }} down
       when: inventory_hostname == ansible_play_hosts[0]
 
     - name: Wait for topology change
-      wait_for:
+      ansible.builtin.wait_for:
         timeout: 8
       when: inventory_hostname == ansible_play_hosts[0]
 
     - name: Refresh facts for ip addresses on all nodes
-      setup:
+      ansible.builtin.setup:
         gather_subset: network
 
     - name: Compare all the hosts IPs with the vrrp_ip
-      set_fact:
+      ansible.builtin.set_fact:
         is_there_master_ip_somewhere: "{{ ansible_play_hosts_all | map('extract', hostvars, 'ansible_all_ipv4_addresses') | flatten | intersect([vrrp_ip]) }}"
       run_once: True
 
     - name: Fail if no one has the vrrp_ip
-      assert:
+      ansible.builtin.assert:
         that:
           is_there_master_ip_somewhere | length > 0
       run_once: True
 
     # Check master is back online is done on verify
     - name: Restore network connectivity on the initial master node
-      command: ip link set dev {{ vrrp_nic }} up
+      ansible.builtin.command: ip link set dev {{ vrrp_nic }} up
       when: inventory_hostname == ansible_play_hosts[0]
 
     - name: Wait for topology change
-      wait_for:
+      ansible.builtin.wait_for:
         timeout: 8
       when: inventory_hostname == ansible_play_hosts[0]

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -8,17 +8,23 @@
   gather_facts: yes
   tasks:
     - name: Define vrrp nic
-      set_fact:
+      ansible.builtin.set_fact:
         vrrp_nic: "{{ ((ansible_interfaces | reject('equalto','lo')) | difference([ansible_default_ipv4.interface]))[0] | string }}"
 
     - name: Show ansible facts
-      debug:
+      ansible.builtin.debug:
         var: ansible_facts
         verbosity: 3
 
+    - name: Get presend instance configurations
+      ansible.builtin.command: "ls -la {{ keepalived_config_directory_path }}/instances/"
+      changed_when: false
+      register: dir_out
+
     - name: Ensure the first node is master
-      assert:
+      ansible.builtin.assert:
         that:
           - "'ipv4_secondaries' in ansible_{{ vrrp_nic }}"
           - "ansible_{{ vrrp_nic }}['ipv4_secondaries'][0]['address'] == '192.168.33.2'"
+          - dir_out.stdout_lines == 'int.conf'
       when: inventory_hostname == ansible_play_hosts[0]

--- a/molecule/default/verify.yml
+++ b/molecule/default/verify.yml
@@ -16,7 +16,7 @@
         var: ansible_facts
         verbosity: 3
 
-    - name: Get presend instance configurations
+    - name: Get present instance configurations
       ansible.builtin.command: "ls -la {{ keepalived_config_directory_path }}/instances/"
       changed_when: false
       register: dir_out

--- a/tasks/create_configuration.yml
+++ b/tasks/create_configuration.yml
@@ -20,6 +20,18 @@
   notify:
     - reload keepalived
 
+- name: Configure keepalived track files
+  ansible.builtin.template:
+    src: keepalived_track_files.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/track_files/{{ item.key }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_track_files is defined
+    - item.value.state | d('present') == 'present'
+  loop: "{{ keepalived_track_files | dict2items }}"
+  notify:
+    - reload keepalived
+
 - name: Configure keepalived sync_groups
   ansible.builtin.template:
     src: keepalived_sync_groups.conf.j2

--- a/tasks/create_configuration.yml
+++ b/tasks/create_configuration.yml
@@ -1,0 +1,81 @@
+---
+
+- name: Configure keepalived
+  ansible.builtin.template:
+    src: keepalived.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/{{ keepalived_config_base_file }}"
+    mode: "0640"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived script
+  ansible.builtin.template:
+    src: keepalived_script.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/scripts/{{ item.key }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_scripts is defined
+    - item.value.state | d('present') == 'present'
+  loop: "{{ keepalived_scripts | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived sync_groups
+  ansible.builtin.template:
+    src: keepalived_sync_groups.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/sync_groups/{{ item.key }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_sync_groups is defined
+    - item.value.state | d('present') == 'present'
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived instances
+  ansible.builtin.template:
+    src: keepalived_instances.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/instances/{{ item.key }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_instances is defined
+    - item.value.state | d('present') in ['present', 'MASTER', 'BACKUP']
+  loop: "{{ keepalived_instances | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived service groups
+  ansible.builtin.template:
+    src: keepalived_virtual_server_groups.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/groups/{{ item.name }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_virtual_server_groups is defined
+    - item.name.state | d('present') == 'present'
+  loop: "{{ keepalived_virtual_server_groups }}"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived single services
+  ansible.builtin.template:
+    src: keepalived_single_services.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/services/single_{{ item.ip | replace('.', '_') }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_virtual_servers is defined
+    - item.ip.state | d('present') == 'present'
+  loop: "{{ keepalived_virtual_servers }}"
+  notify:
+    - reload keepalived
+
+- name: Configure keepalived group services
+  ansible.builtin.template:
+    src: keepalived_group_services.conf.j2
+    dest: "{{ keepalived_config_directory_path }}/services/group_{{ item.name }}.conf"
+    mode: "0640"
+  when:
+    - keepalived_virtual_server_groups is defined
+    - item.name.state | d('present') == 'present'
+  loop: "{{ keepalived_virtual_server_groups }}"
+  notify:
+    - reload keepalived

--- a/tasks/drop_files.yml
+++ b/tasks/drop_files.yml
@@ -1,0 +1,111 @@
+---
+
+- name: Dropping the tracking scripts
+  ansible.builtin.copy:
+    src: "{{ item.value.src_check_script }}"
+    dest: "{{ item.value.dest_check_script | default(item.value.check_script) }}"
+    mode: "0755"
+  loop: "{{ keepalived_scripts | dict2items | default('{}') }}"
+  when: item.value.src_check_script is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the general notification scripts
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_script }}"
+    dest: "{{ item.value.notify_script }}"
+    mode: "0755"
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  when: item.value.src_notify_script is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for switching to master
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_master }}"
+    dest: "{{ item.value.notify_master }}"
+    mode: "0755"
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  when: item.value.src_notify_master is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for switching to backup
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_backup }}"
+    dest: "{{ item.value.notify_backup }}"
+    mode: "0755"
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  when: item.value.src_notify_backup is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for failures
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_fault }}"
+    dest: "{{ item.value.notify_fault }}"
+    mode: "0755"
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  when: item.value.src_notify_fault is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the general notification scripts (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_script }}"
+    dest: "{{ item.value.notify_script }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_script is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for switching to master (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_master }}"
+    dest: "{{ item.value.notify_master }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_master is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for lower priority master case (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_master_rx_lower_pri }}"
+    dest: "{{ item.value.notify_master_rx_lower_pri }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_master_rx_lower_pri is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for switching to backup (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_backup }}"
+    dest: "{{ item.value.notify_backup }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_backup is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for stopping vrrp (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_stop }}"
+    dest: "{{ item.value.notify_stop }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_stop is defined
+  notify:
+    - reload keepalived
+
+- name: Dropping the notification scripts for failures (instances)
+  ansible.builtin.copy:
+    src: "{{ item.value.src_notify_fault }}"
+    dest: "{{ item.value.notify_fault }}"
+    mode: "0755"
+  loop: "{{ keepalived_instances | dict2items }}"
+  when: item.value.src_notify_fault is defined
+  notify:
+    - reload keepalived

--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -14,22 +14,23 @@
 # limitations under the License.
 
 - name: Get list of SELinux modules loaded
-  command: semodule -l
+  ansible.builtin.command: semodule -l
   changed_when: False
   register: selinux_modules
   check_mode: no
 
 - name: Ensure SELinux packages are installed
-  yum:
+  ansible.builtin.package:
     name: "{{ keepalived_selinux_packages }}"
     state: present
   when:
     - '"keepalived_ping" not in selinux_modules.stdout'
 
-- include_tasks:
+- name: Compile SELinux
+  ansible.builtin.include_tasks:
     file: keepalived_selinux_compile.yml
   when:
     - selinux_policy_name not in selinux_modules.stdout
-  with_items: "{{ keepalived_selinux_compile_rules }}"
+  loop: "{{ keepalived_selinux_compile_rules }}"
   loop_control:
     loop_var: selinux_policy_name

--- a/tasks/keepalived_selinux_compile.yml
+++ b/tasks/keepalived_selinux_compile.yml
@@ -14,13 +14,13 @@
 # limitations under the License.
 
 - name: Create directory for compiling SELinux role
-  file:
+  ansible.builtin.file:
     path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
     state: directory
     mode: '0755'
 
 - name: Deploy SELinux policy source file
-  copy:
+  ansible.builtin.copy:
     src: "{{ selinux_policy_name }}.te"
     dest: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}/{{ selinux_policy_name }}.te"
     owner: root
@@ -28,16 +28,16 @@
     mode: "0755"
 
 - name: Compile and load SELinux module
-  command: "{{ item }}"
+  ansible.builtin.command: "{{ item }}"
   args:
     creates: "/etc/selinux/targeted/active/modules/400/{{ selinux_policy_name }}/cil"
     chdir: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
-  with_items:
+  loop:
     - checkmodule -M -m -o {{ selinux_policy_name }}.mod {{ selinux_policy_name }}.te
     - semodule_package -o {{ selinux_policy_name }}.pp -m {{ selinux_policy_name }}.mod
     - semodule -i {{ selinux_policy_name }}.pp
 
 - name: Remove temporary directory
-  file:
+  ansible.builtin.file:
     path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
     state: absent

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -103,6 +103,7 @@
   loop:
     - "{{ keepalived_config_directory_path }}"
     - "{{ keepalived_config_directory_path }}/scripts"
+    - "{{ keepalived_config_directory_path }}/track_files"
     - "{{ keepalived_config_directory_path }}/sync_groups"
     - "{{ keepalived_config_directory_path }}/instances"
     - "{{ keepalived_config_directory_path }}/groups"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -14,7 +14,7 @@
 # limitations under the License.
 
 - name: Gather variables for each operating system
-  include_vars: "{{ item }}"
+  ansible.builtin.include_vars: "{{ item }}"
   with_first_found:
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_version | lower }}.yml"
     - "{{ ansible_distribution | lower }}-{{ ansible_distribution_major_version | lower }}.yml"
@@ -24,7 +24,8 @@
   tags:
     - always
 
-- include_tasks:
+- name: Setup SELinux
+  ansible.builtin.include_tasks:
     file: keepalived_selinux.yml
   when:
     - keepalived_selinux_compile_rules | length > 0
@@ -34,7 +35,7 @@
     - keepalived-config
 
 - name: install keepalived package(s)
-  package:
+  ansible.builtin.package:
     name: "{{ [keepalived_package_name] + keepalived_scripts_packages }}"
     state: "{{ keepalived_package_state }}"
     update_cache: "{{ (ansible_pkg_mgr == 'apt') | ternary('yes', omit) }}"
@@ -46,33 +47,33 @@
     - restart keepalived
 
 - name: Ensure no new "samples" folder appeared
-  file:
+  ansible.builtin.file:
     path: /etc/keepalived/samples/
     state: absent
   when:
     - ansible_os_family | lower == 'debian'
 
 - name: Get IPv6 enabled state
-  slurp:
+  ansible.builtin.slurp:
     src: /sys/module/ipv6/parameters/disable
   register: _ipv6_disabled
   tags:
     - keepalived-install
 
 - name: Check if IPv6 is enabled
-  set_fact:
+  ansible.builtin.set_fact:
     ipv6_enabled: "{{ not _ipv6_disabled.failed and '0' in (_ipv6_disabled.content | b64decode) }}"
   tags:
     - keepalived-install
 
 - name: Allow consuming apps to bind on non local addresses for IPv4
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     sysctl_set: yes
     state: present
   when: keepalived_bind_on_non_local | bool
-  with_items:
+  loop:
     - name: "net.ipv4.ip_nonlocal_bind"
       value: 1
     - name: "net.ipv4.tcp_retries2"
@@ -81,183 +82,80 @@
     - keepalived-install
 
 - name: Allow consuming apps to bind on non local addresses for IPv6
-  sysctl:
+  ansible.posix.sysctl:
     name: "{{ item.name }}"
     value: "{{ item.value }}"
     sysctl_set: yes
     state: present
   when: keepalived_bind_on_non_local | bool
         and ipv6_enabled
-  with_items:
+  loop:
     - name: "net.ipv6.ip_nonlocal_bind"
       value: 1
   tags:
     - keepalived-install
 
-- name: Configure keepalived
-  template:
-    src: keepalived.conf.j2
-    dest: "{{ keepalived_config_file_path }}"
-    mode: "0640"
+- name: Create configuration directories if they do not exist
+  ansible.builtin.file:
+    path: "{{ item }}"
+    state: directory
+    mode: '0755'
+  loop:
+    - "{{ keepalived_config_directory_path }}"
+    - "{{ keepalived_config_directory_path }}/scripts"
+    - "{{ keepalived_config_directory_path }}/sync_groups"
+    - "{{ keepalived_config_directory_path }}/instances"
+    - "{{ keepalived_config_directory_path }}/groups"
+    - "{{ keepalived_config_directory_path }}/services"
   tags:
     - keepalived-config
-  notify:
-    - reload keepalived
+
+- name: Create keepalived configuration snippets
+  ansible.builtin.include_tasks:
+    file: create_configuration.yml
+  tags:
+    - keepalived-config
+
+- name: Remove keepalived configuration snippets
+  ansible.builtin.include_tasks:
+    file: remove_configuration.yml
+  tags:
+    - keepalived-config
 
 - name: Check that daemon options file exists
-  stat:
+  ansible.builtin.stat:
     path: "{{ keepalived_daemon_options_file_path }}"
   register: keepalived_daemon_options_file
   tags:
     - keepalived-config
 
 - name: Configure keepalived extra params
-  lineinfile:
+  ansible.builtin.lineinfile:
     line: "{{ item }}"
     regexp: "^{{ item.split('=')[0] }}"
     dest: "{{ keepalived_daemon_options_file_path }}"
     state: present
-  with_items: "{{ keepalived_daemon_default_options_overrides }}"
+  loop: "{{ keepalived_daemon_default_options_overrides }}"
   when: keepalived_daemon_options_file.stat.exists
   tags:
     - keepalived-config
   notify:
     - restart keepalived
 
-- name: Dropping the tracking scripts
-  copy:
-    src: "{{ item.value.src_check_script }}"
-    dest: "{{ item.value.dest_check_script|default(item.value.check_script) }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_scripts | default('{}') }}"
-  when: item.value.src_check_script is defined
+- name: Drop additional files
+  ansible.builtin.include_tasks:
+    file: drop_files.yml
   tags:
     - keepalived-config
-  notify:
-    - reload keepalived
 
-- name: Dropping the general notification scripts
-  copy:
-    src: "{{ item.value.src_notify_script }}"
-    dest: "{{ item.value.notify_script }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_sync_groups }}"
-  when: item.value.src_notify_script is defined
+- name: remove additional files
+  ansible.builtin.include_tasks:
+    file: remove_files.yml
   tags:
     - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for switching to master
-  copy:
-    src: "{{ item.value.src_notify_master }}"
-    dest: "{{ item.value.notify_master }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_sync_groups }}"
-  when: item.value.src_notify_master is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for switching to backup
-  copy:
-    src: "{{ item.value.src_notify_backup }}"
-    dest: "{{ item.value.notify_backup }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_sync_groups }}"
-  when: item.value.src_notify_backup is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for failures
-  copy:
-    src: "{{ item.value.src_notify_fault }}"
-    dest: "{{ item.value.notify_fault }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_sync_groups }}"
-  when: item.value.src_notify_fault is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the general notification scripts (instances)
-  copy:
-    src: "{{ item.value.src_notify_script }}"
-    dest: "{{ item.value.notify_script }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_script is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for switching to master (instances)
-  copy:
-    src: "{{ item.value.src_notify_master }}"
-    dest: "{{ item.value.notify_master }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_master is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for lower priority master case (instances)
-  copy:
-    src: "{{ item.value.src_notify_master_rx_lower_pri }}"
-    dest: "{{ item.value.notify_master_rx_lower_pri }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_master_rx_lower_pri is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for switching to backup (instances)
-  copy:
-    src: "{{ item.value.src_notify_backup }}"
-    dest: "{{ item.value.notify_backup }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_backup is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for stopping vrrp (instances)
-  copy:
-    src: "{{ item.value.src_notify_stop }}"
-    dest: "{{ item.value.notify_stop }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_stop is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
-
-- name: Dropping the notification scripts for failures (instances)
-  copy:
-    src: "{{ item.value.src_notify_fault }}"
-    dest: "{{ item.value.notify_fault }}"
-    mode: "0755"
-  with_dict: "{{ keepalived_instances }}"
-  when: item.value.src_notify_fault is defined
-  tags:
-    - keepalived-config
-  notify:
-    - reload keepalived
 
 - name: Make directory for keepalived's systemd overrides
-  file:
+  ansible.builtin.file:
     path: /etc/systemd/system/keepalived.service.d/
     state: directory
     mode: "0755"
@@ -265,14 +163,14 @@
     - keepalived_systemd_overrides | bool
 
 - name: Apply keepalived override to start after network is up
-  ini_file:
+  community.general.ini_file:
     path: /etc/systemd/system/keepalived.service.d/override.conf
     create: yes
     section: 'Unit'
     option: "{{ item }}"
     value: 'network-online.target'
     mode: '0644'
-  with_items:
+  loop:
     - 'Wants'
     - 'After'
   when:
@@ -281,7 +179,7 @@
     - restart keepalived
 
 - name: Apply keepalived override to restart service always
-  ini_file:
+  community.general.ini_file:
     path: /etc/systemd/system/keepalived.service.d/override.conf
     section: 'Service'
     option: "Restart"
@@ -294,49 +192,15 @@
     - restart keepalived
 
 - name: Remove keepalived overrides
-  file:
+  ansible.builtin.file:
     path: /etc/systemd/system/keepalived.service.d/override.conf
     state: absent
   when:
     - not (keepalived_systemd_overrides | bool)
 
-# Until  https://github.com/ansible/ansible/pull/72337 is fixed, we need to not use
-# the service/systemd module.
-#- name: Ensuring keepalived is enabled
-#  service:
-#    daemon_reload: yes
-#    name: "{{ keepalived_service_name }}"
-#    enabled: "yes"
-#    masked: "no"
-#
-
-# Reload systemd is necessary if new packages, or changes of overrides.
-# Because there is no notify on those tasks, and that the notify would be happening after the
-# task to ensure keepalived is enabled, move it to an unconditional task here.
-# When the bug above is fixed with the service/systemd module, ensure everything is
-# done in a single handler, tackling the daemon-reloads and the restart of the service,
-# plus a single task, handling the daemon-reload and ensuring the service is enabled
-# on the first install (the changes in systemd files would have to trigger the
-# handler to restart the service).
-- name: Check if keepalived is enabled
-  shell: "systemctl daemon-reload && systemctl is-enabled {{ keepalived_service_name }}"
-  register: isenabled
-  changed_when: (isenabled.stdout == "disabled" or isenabled.stdout == "masked") and isenabled.rc != 0
-  failed_when: (isenabled.stdout != "disabled" and isenabled.stdout != "masked") and isenabled.rc != 0
-  tags:
-    - skip_ansible_lint
-
-- name: Unmask keepalived if necessary
-  command: "systemctl unmask {{ keepalived_service_name }}"
-  when:
-    - isenabled is changed
-    - isenabled.stdout == "masked"
-  tags:
-    - skip_ansible_lint
-
-- name: ensure keepalived is enabled
-  command: "systemctl enable {{ keepalived_service_name }} --now"
-  when:
-    - isenabled is changed
-  tags:
-    - skip_ansible_lint
+- name: Ensuring keepalived is enabled
+  ansible.builtin.service:
+    daemon_reload: yes
+    name: "{{ keepalived_service_name }}"
+    enabled: "yes"
+    masked: "no"

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -148,12 +148,6 @@
   tags:
     - keepalived-config
 
-- name: remove additional files
-  ansible.builtin.include_tasks:
-    file: remove_files.yml
-  tags:
-    - keepalived-config
-
 - name: Make directory for keepalived's systemd overrides
   ansible.builtin.file:
     path: /etc/systemd/system/keepalived.service.d/

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -95,6 +95,23 @@
   tags:
     - keepalived-install
 
+- name: Get keepalived directory listing
+  ansible.builtin.find:
+    path: "{{ keepalived_config_directory_path }}"
+    file_type: any
+    hidden: yes
+  register: keepalived_content_result
+  when: keepalived_flush_configuration | bool
+
+- name: Remove keepalived directory content
+  ansible.builtin.file:
+    path: "{{ item.path }}"
+    state: absent
+  when: keepalived_flush_configuration | bool
+  loop_control:
+    label: "{{ item.path }}"
+  loop: "{{ keepalived_content_result.files }}"
+
 - name: Create configuration directories if they do not exist
   ansible.builtin.file:
     path: "{{ item }}"

--- a/tasks/remove_configuration.yml
+++ b/tasks/remove_configuration.yml
@@ -11,6 +11,17 @@
   notify:
     - reload keepalived
 
+- name: Remove keepalived track file
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/track_files/{{ item.key }}.conf"
+    state: absent
+  when:
+    - keepalived_track_files is defined
+    - item.value.state | d('present') == 'absent'
+  loop: "{{ keepalived_track_files | dict2items }}"
+  notify:
+    - reload keepalived
+
 - name: Remove keepalived sync_groups
   ansible.builtin.file:
     path: "{{ keepalived_config_directory_path }}/sync_groups/{{ item.key }}.conf"

--- a/tasks/remove_configuration.yml
+++ b/tasks/remove_configuration.yml
@@ -1,0 +1,67 @@
+---
+
+- name: Remove keepalived script
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/scripts/{{ item.key }}.conf"
+    state: absent
+  when:
+    - keepalived_scripts is defined
+    - item.value.state | d('present') == 'absent'
+  loop: "{{ keepalived_scripts | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Remove keepalived sync_groups
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/sync_groups/{{ item.key }}.conf"
+    state: absent
+  when:
+    - keepalived_sync_groups is defined
+    - item.value.state | d('present') == 'absent'
+  loop: "{{ keepalived_sync_groups | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Remove keepalived instances
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/instances/{{ item.key }}.conf"
+    state: absent
+  when:
+    - keepalived_instances is defined
+    - item.value.state | d('present') == 'absent'
+  loop: "{{ keepalived_instances | dict2items }}"
+  notify:
+    - reload keepalived
+
+- name: Remove keepalived service groups
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/groups/{{ item.name }}.conf"
+    state: absent
+  when:
+    - keepalived_virtual_server_groups is defined
+    - item.name.state | d('present') == 'absent'
+  loop: "{{ keepalived_virtual_server_groups }}"
+  notify:
+    - reload keepalived
+
+- name: Remove keepalived single services
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/services/single_{{ item.ip | replace('.', '_') }}.conf"
+    state: absent
+  when:
+    - keepalived_virtual_servers is defined
+    - item.ip.state | d('present') == 'absent'
+  loop: "{{ keepalived_virtual_servers }}"
+  notify:
+    - reload keepalived
+
+- name: Remove keepalived group services
+  ansible.builtin.file:
+    path: "{{ keepalived_config_directory_path }}/services/group_{{ item.name }}.conf"
+    state: absent
+  when:
+    - keepalived_virtual_server_groups is defined
+    - item.name.state | d('present') == 'absent'
+  loop: "{{ keepalived_virtual_server_groups }}"
+  notify:
+    - reload keepalived

--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -26,8 +26,9 @@ global_defs {
 }
 {% endif %}
 
-include /etc/keepalived/scripts/*.conf
-include /etc/keepalived/sync_groups/*.conf
-include /etc/keepalived/instances/*.conf
-include /etc/keepalived/groups/*.conf
-include /etc/keepalived/services/*.conf
+include {{ keepalived_config_directory_path }}/scripts/*.conf
+include {{ keepalived_config_directory_path }}/track_files/*.conf
+include {{ keepalived_config_directory_path }}/sync_groups/*.conf
+include {{ keepalived_config_directory_path }}/instances/*.conf
+include {{ keepalived_config_directory_path }}/groups/*.conf
+include {{ keepalived_config_directory_path }}/services/*.conf

--- a/templates/keepalived_group_services.conf.j2
+++ b/templates/keepalived_group_services.conf.j2
@@ -1,4 +1,5 @@
----
+#jinja2: lstrip_blocks: True
+{#
 # Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
@@ -12,12 +13,20 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed|bool %}
+{{ ansible_managed | comment }}
+{% endif %}
 
-keepalived_package_name: "keepalived"
-keepalived_service_name: "keepalived.service"
-keepalived_config_directory_path: "/etc/keepalived"
-keepalived_config_base_file: "keepalived.conf"
-_keepalived_daemon_options_file_path: "/etc/default/keepalived"
-
-# Packages for Selinux
-keepalived_selinux_packages: []
+{% set vserver_group = item %}
+virtual_server group {{ vserver_group.name }} {
+  {# set variable to prevent duplicate code for the same task #}
+  {% set vserver = vserver_group %}
+  {% include './templates/keepalived-virtual-server.j2' %}
+  {% for rserver in vserver_group.real_servers %}
+  real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% include './templates/keepalived-real-server.j2' %}
+    {% include './templates/keepalived-checks.j2' %}
+  }
+  {% endfor %}
+}

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -103,6 +103,13 @@ vrrp_instance {{ name }} {
     {% endfor %}
   }
   {% endif %}
+  {% if instance.track_files is defined %}
+  track_file {
+    {% for track_file in instance.track_files %}
+    {{ track_file }}
+    {% endfor %}
+  }
+  {% endif %}
 
   {% if instance.track_interfaces is defined %}
   track_interface {

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -45,10 +45,12 @@ vrrp_instance {{ name }} {
   {% if instance.dont_track_primary is defined and instance.dont_track_primary | bool %}
   dont_track_primary                               # Override VRRP RFC dont_track_primary default
   {% endif %}
-  {% if instance.accept is defined and instance.accept | bool %}
+  {% if instance.accept is defined %}
+  {% if instance.accept | bool %}
   accept
   {% else %}
   no_accept
+  {% endif %}
   {% endif %}
   {% if instance.native_ipv6 is defined and instance.native_ipv6 | bool %}
   native_ipv6

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -96,6 +96,7 @@ vrrp_instance {{ name }} {
   {% endfor %}
   }
   {% endif %}
+
   {% if instance.track_scripts is defined %}
   track_script {
     {% for track_script in instance.track_scripts %}
@@ -110,7 +111,6 @@ vrrp_instance {{ name }} {
     {% endfor %}
   }
   {% endif %}
-
   {% if instance.track_interfaces is defined %}
   track_interface {
     {% for track_interface in instance.track_interfaces %}

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -45,6 +45,12 @@ vrrp_instance {{ name }} {
   {% if instance.dont_track_primary is defined and instance.dont_track_primary | bool %}
   dont_track_primary                               # Override VRRP RFC dont_track_primary default
   {% endif %}
+  {% if instance.accept is defined %}
+  {% if instance.accept | bool %}
+  accept
+  {% else %}
+  no_accept
+  {% endif %}
   {% if instance.native_ipv6 is defined and instance.native_ipv6 | bool %}
   native_ipv6
   {% endif %}

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -1,0 +1,129 @@
+#jinja2: lstrip_blocks: True
+{#
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed|bool %}
+{{ ansible_managed | comment }}
+{% endif %}
+
+{% set name = item.key %}
+{% set instance = item.value %}
+vrrp_instance {{ name }} {
+  interface {{ instance.interface }}
+{% if instance.state in ['MASTER', 'BACKUP'] %}
+  state {{ instance.state }}
+{% endif %}
+  virtual_router_id {{ instance.virtual_router_id }}
+  priority {{ instance.priority }}
+  {% if instance.use_vmac is defined and instance.use_vmac | bool %}
+  use_vmac                                         # Use virtual MAC address
+  {% endif %}
+  {% if instance.vmac_xmit_base is defined and instance.vmac_xmit_base | bool %}
+  vmac_xmit_base                                   # Use physical MAC address for communication
+  {% endif %}
+  {% if instance.nopreempt is defined and instance.nopreempt | bool %}
+  nopreempt                                        # Override VRRP RFC preemption default
+  {% endif %}
+  {% if instance.preempt_delay is defined %}
+  preempt_delay {{ instance.preempt_delay }}       # Seconds after startup until preemption. 0 (default) to 1,000.
+  {% endif %}
+  {% if instance.advert_int is defined %}
+  advert_int {{ instance.advert_int }}
+  {% endif %}
+  {% if instance.dont_track_primary is defined and instance.dont_track_primary | bool %}
+  dont_track_primary                               # Override VRRP RFC dont_track_primary default
+  {% endif %}
+  {% if instance.native_ipv6 is defined and instance.native_ipv6 | bool %}
+  native_ipv6
+  {% endif %}
+
+  {% if instance.authentication_password is defined %}
+  authentication {
+    auth_type PASS
+    auth_pass {{instance.authentication_password}}
+  }
+  {% endif %}
+  {% if instance.unicast_src_ip is defined and instance.unicast_peers|length > 0 %}
+  unicast_src_ip {{ instance.unicast_src_ip }}
+  unicast_peer {
+  {% for peer in instance.unicast_peers %}
+    {{ peer }}
+  {% endfor %}
+  }
+  {% endif %}
+  virtual_ipaddress {
+    {% for vip in instance.vips %}
+    {{ vip }}
+    {% endfor %}
+  }
+  {% if instance.vips_excluded is defined %}
+  virtual_ipaddress_excluded {
+    {% for vip in instance.vips_excluded %}
+    {{ vip }}
+    {% endfor %}
+  }
+  {% endif %}
+  {% if instance.virtual_routes is defined %}
+  virtual_routes {
+  {% for route in instance.virtual_routes %}
+    {{ route }}
+  {% endfor %}
+  }
+  {% endif %}
+  {% if instance.virtual_rules is defined %}
+  virtual_rules {
+  {% for rule in instance.virtual_rules %}
+    {{ rule }}
+  {% endfor %}
+  }
+  {% endif %}
+  {% if instance.track_scripts is defined %}
+  track_script {
+    {% for track_script in instance.track_scripts %}
+    {{ track_script }}
+    {% endfor %}
+  }
+  {% endif %}
+
+  {% if instance.track_interfaces is defined %}
+  track_interface {
+    {% for track_interface in instance.track_interfaces %}
+    {{ track_interface }}
+    {% endfor %}
+  }
+  {% endif %}
+
+  {% if instance.notify_script is defined %}
+  notify "{{ instance.notify_script }}"
+  {% endif %}
+  {% if instance.notify_master is defined %}
+  notify_master "{{ instance.notify_master }}"
+  {% endif %}
+  {% if instance.notify_master_rx_lower_pri is defined %}
+  notify_master_rx_lower_pri "{{ instance.notify_master_rx_lower_pri }}"
+  {% endif %}
+  {% if instance.notify_backup is defined %}
+  notify_backup "{{ instance.notify_backup }}"
+  {% endif %}
+  {% if instance.notify_fault is defined %}
+  notify_fault "{{ instance.notify_fault }}"
+  {% endif %}
+  {% if instance.notify_stop is defined %}
+  notify_stop "{{ instance.notify_stop }}"
+  {% endif %}
+  {% if instance.smtp_alert is defined and instance.smtp_alert | bool %}
+  smtp_alert # Send email notification during state transition
+  {% endif %}
+}

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -45,8 +45,7 @@ vrrp_instance {{ name }} {
   {% if instance.dont_track_primary is defined and instance.dont_track_primary | bool %}
   dont_track_primary                               # Override VRRP RFC dont_track_primary default
   {% endif %}
-  {% if instance.accept is defined %}
-  {% if instance.accept | bool %}
+  {% if instance.accept is defined and instance.accept | bool %}
   accept
   {% else %}
   no_accept

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -62,7 +62,7 @@ vrrp_instance {{ name }} {
     auth_pass {{instance.authentication_password}}
   }
   {% endif %}
-  {% if instance.unicast_src_ip is defined and instance.unicast_peers|length > 0 %}
+  {% if instance.unicast_src_ip is defined and instance.unicast_peers | length > 0 %}
   unicast_src_ip {{ instance.unicast_src_ip }}
   unicast_peer {
   {% for peer in instance.unicast_peers %}
@@ -75,7 +75,7 @@ vrrp_instance {{ name }} {
     {{ vip }}
     {% endfor %}
   }
-  {% if instance.vips_excluded is defined and instance.vips_excluded is iterable %}
+  {% if instance.vips_excluded is defined and instance.vips_excluded | length > 0 %}
   virtual_ipaddress_excluded {
     {% for vip in instance.vips_excluded %}
     {{ vip }}

--- a/templates/keepalived_instances.conf.j2
+++ b/templates/keepalived_instances.conf.j2
@@ -68,7 +68,7 @@ vrrp_instance {{ name }} {
     {{ vip }}
     {% endfor %}
   }
-  {% if instance.vips_excluded is defined %}
+  {% if instance.vips_excluded is defined and instance.vips_excluded is iterable %}
   virtual_ipaddress_excluded {
     {% for vip in instance.vips_excluded %}
     {{ vip }}

--- a/templates/keepalived_script.conf.j2
+++ b/templates/keepalived_script.conf.j2
@@ -1,0 +1,37 @@
+#jinja2: lstrip_blocks: True
+{#
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed | bool %}
+{{ ansible_managed | comment }}
+{% endif %}
+
+{% set name = item.key %}
+{% set details = item.value %}
+vrrp_script {{ name }} {
+  script "{{ details.check_script }}"
+  interval {{ details.interval | default(5) }}   # checking every {{ details.interval | default(5) }} seconds (default: 5 seconds)
+  fall {{ details.fall | default(3) }}           # require {{ details.fall | default(3) }} failures for KO (default: 3)
+  rise {{ details.rise | default(6) }}           # require {{ details.rise | default(6) }} successes for OK (default: 6)
+  {% if details.weight is defined %}
+  weight {{ details.weight | default(0) }}       # adjust priority by this weight, (default: 0)
+  {% endif %}
+  {% if details.timeout is defined %}
+  timeout {{ details.timeout }}                  # allow scripts like ping to succeed, before timing out
+  {% endif %}
+  {% if details.user is defined %}
+  user {{ details.user }}                        # user/group names to run script under.
+  {% endif %}
+}

--- a/templates/keepalived_single_services.conf.j2
+++ b/templates/keepalived_single_services.conf.j2
@@ -18,16 +18,19 @@
 {{ ansible_managed | comment }}
 {% endif %}
 
-{% if keepalived_global_defs is defined %}
-global_defs {
-{% for def in keepalived_global_defs %}
-  {{ def }}
-{% endfor %}
-}
-{% endif %}
+{# keepalived_virtual_servers without groups #}
+{% set vserver = item %}
+virtual_server {{ vserver.ip }} {{ vserver.port }} {
+  {% include './templates/keepalived-virtual-server.j2' %}
 
-include /etc/keepalived/scripts/*.conf
-include /etc/keepalived/sync_groups/*.conf
-include /etc/keepalived/instances/*.conf
-include /etc/keepalived/groups/*.conf
-include /etc/keepalived/services/*.conf
+  {% for rserver in vserver.real_servers %}
+  real_server {{ rserver.ip }} {{ rserver.port }} {
+    {% include './templates/keepalived-real-server.j2' %}
+    {% include './templates/keepalived-checks.j2' %}
+  }
+  {% endfor %}
+  {% if vserver.sorry_server is defined %}
+  sorry_server {{ vserver.sorry_server.ip }} {{ vserver.sorry_server.port }}
+  {% endif %}
+
+}

--- a/templates/keepalived_sync_groups.conf.j2
+++ b/templates/keepalived_sync_groups.conf.j2
@@ -1,0 +1,51 @@
+#jinja2: lstrip_blocks: True
+{#
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed|bool %}
+{{ ansible_managed | comment }}
+{% endif %}
+
+{% set name = item.key %}
+{% set sync_group = item.value %}
+vrrp_sync_group {{ name }} {
+  group {
+    {% for instance in sync_group.instances %}
+    {{ instance }}
+    {% endfor %}
+  }
+  {% if sync_group.notify_script is defined %}
+  notify "{{ sync_group.notify_script }}"
+  {% endif %}
+  {% if sync_group.notify_master is defined %}
+  notify_master "{{ sync_group.notify_master }}"
+  {% endif %}
+  {% if sync_group.notify_backup is defined %}
+  notify_backup "{{ sync_group.notify_backup }}"
+  {% endif %}
+  {% if sync_group.notify_fault is defined %}
+  notify_fault "{{ sync_group.notify_fault }}"
+  {% endif %}
+  {% if sync_group.global_tracking is defined and sync_group.global_tracking | bool %}
+  global_tracking                                # All VRRP share the same tracking config.
+  {% endif %}
+  {% if sync_group.track_scripts is defined %}
+  track_script {
+    {% for track_script in sync_group.track_scripts %}
+    {{ track_script }}
+    {% endfor %}
+  }
+  {% endif %}
+}

--- a/templates/keepalived_sync_groups.conf.j2
+++ b/templates/keepalived_sync_groups.conf.j2
@@ -48,4 +48,11 @@ vrrp_sync_group {{ name }} {
     {% endfor %}
   }
   {% endif %}
+  {% if sync_group.track_files is defined %}
+  track_file {
+    {% for track_file in sync_group.track_files %}
+    {{ track_file }}
+    {% endfor %}
+  }
+  {% endif %}
 }

--- a/templates/keepalived_track_files.conf.j2
+++ b/templates/keepalived_track_files.conf.j2
@@ -1,0 +1,29 @@
+#jinja2: lstrip_blocks: True
+{#
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed | bool %}
+{{ ansible_managed | comment }}
+{% endif %}
+
+{% set name = item.key %}
+{% set details = item.value %}
+vrrp_track_file {{ name }} {
+  file "{{ details.file }}"
+  weight {{ details.weight | default(1) }} # multiply with weight in file (default: 1, i.e. literal value from file)
+  {% if details.init_file | default(false) | bool %}
+  init_file{% if details.init_file_value is defined %} {{ details.init_file_value }}{% endif %}{% if details.init_file_overwrite | default(false) | bool %} overwrite{% endif %}
+  {% endif %}
+}

--- a/templates/keepalived_virtual_server_groups.conf.j2
+++ b/templates/keepalived_virtual_server_groups.conf.j2
@@ -1,5 +1,6 @@
----
-# Copyright 2021, Sherwin Daganato <sherwin@daganato.com>
+#jinja2: lstrip_blocks: True
+{#
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -12,15 +13,17 @@
 # WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
 # See the License for the specific language governing permissions and
 # limitations under the License.
+-#}
+{% if keepalived_show_ansible_managed|bool %}
+{{ ansible_managed | comment }}
+{% endif %}
 
-keepalived_package_name: "keepalived"
-keepalived_service_name: "keepalived"
-keepalived_config_directory_path: "/etc/keepalived"
-keepalived_config_base_file: "keepalived.conf"
-_keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
-
-# Packages for Selinux
-keepalived_selinux_packages:
-  - python3-policycoreutils
-  - libselinux
-  - libselinux-devel
+{% set vserver_group = item %}
+virtual_server_group {{ vserver_group.name }} {
+  {% for vserver_group_vip in vserver_group.vips %}
+  {{ vserver_group_vip.ip }} {{ vserver_group_vip.port }}
+  {% endfor %}
+  {% if vserver_group.fwmark is defined %}
+  fwmark {{ vserver_group.fwmark }}
+  {% endif %}
+}

--- a/tests/keepalived_haproxy_backup_edit_example.yml
+++ b/tests/keepalived_haproxy_backup_edit_example.yml
@@ -1,0 +1,135 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_sync_groups:
+  # You can have multiple sync groups. Here is an example of just one.
+  haproxy:
+    # Each group can have muliple instances
+    instances:
+      - ext
+      - int
+    # Uncomment this to have a notification script, triggered on state change.
+    # all the *_scripts can be a direct command, or a path to a script
+    # For the latter, you MUST define a script that will be used a source in
+    # src_*_script (available on the deployment host).
+    # The src_*_script will be uploaded to your destination host at the _script
+    # location
+    #notify_script: /etc/keepalived/haproxy_notify.sh
+    #src_notify_script: <path to source script if notify_script is not a command>
+    # If instead of one notification script handling all types of events, you
+    # want to define script per type of notification, please uncomment this.
+    # They will act before the general notification script.
+    # Their deployment and configuration are like the notify_script
+    #notify_master:
+    #src_notify_master:
+    #notify_backup:
+    #src_notify_backup:
+    #notify_fault:
+    #src_notify_fault:
+
+# Uncomment this to have keepalived status checking. They will run on all the hosts
+# whether it's master or backup. You can have multiple scripts.
+#keepalived_scripts:
+  #haproxy_check_script:
+    # Here is an example with a command instead of a script.
+    # Add src_check_script if you want to run a script instead of a command
+    # and upload it from your deploy host
+    #check_script: "killall -0 haproxy"
+  #pingable_check_script:
+    #check_script: "ping -c 1 193.0.14.129 1>&2"
+    # Interval is the time in seconds between each check
+    #interval: 10
+    # Fall is the time to mark the keepalived status as not ok
+    #fall: 2
+    # Rise is the time to mark the keepalived status as back to ok
+    #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
+
+
+keepalived_instances:
+  #This dict name is the same as the one above, in keepalived_sync_groups.
+  external:
+    state: absent
+  ext:
+    #remember you can use ansible variables here.
+    interface: eth0
+    state: BACKUP
+    virtual_router_id: 100
+    priority: 25
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    vips:
+      - "{{ keepalived_external_vip_cidr | default('127.0.2.1') }} dev {{ keepalived_external_interface | default('eth0') }}"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+  internal:
+    state: absent
+  int:
+    interface: eth1
+    state: BACKUP
+    virtual_router_id: 110
+    priority: 25
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+    vips:
+      - "{{ keepalived_internal_vip_cidr | default('127.0.3.1') }} dev {{ keepalived_internal_interface | default('eth1') }} "
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - ip: '8.8.8.8'
+#        port: '53'
+#        # Currently on MISC_CHECK is supported. Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - ip: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              misc_timeout: '10'
+#              # Optinal, set false or omit to not use it.
+#              warmup: true
+#              # Optinal, set false or omit to not use it.
+#              misc_dynamic: true

--- a/tests/keepalived_haproxy_backup_edit_example.yml
+++ b/tests/keepalived_haproxy_backup_edit_example.yml
@@ -110,7 +110,7 @@ keepalived_instances:
 # Uncomment and adjust to make use of keepalived's virtual_server functions.
 #keepalived_virtual_servers:
 #  # Example with recycled {{ keepalived_internal_vip_cidr }}
-#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#  - ip: "{{ keepalived_internal_vip_cidr | ansible.netcommon.ipaddr('address') }}"
 #    port: '53'
 #    protocol: 'UDP'
 #    lvs_method: 'NAT'

--- a/tests/keepalived_haproxy_backup_example.yml
+++ b/tests/keepalived_haproxy_backup_example.yml
@@ -106,7 +106,7 @@ keepalived_instances:
 # Uncomment and adjust to make use of keepalived's virtual_server functions.
 #keepalived_virtual_servers:
 #  # Example with recycled {{ keepalived_internal_vip_cidr }}
-#  - ip: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#  - ip: "{{ keepalived_internal_vip_cidr | ansible.netcommon.ipaddr('address') }}"
 #    port: '53'
 #    protocol: 'UDP'
 #    lvs_method: 'NAT'

--- a/tests/keepalived_haproxy_combined_edit_example.yml
+++ b/tests/keepalived_haproxy_combined_edit_example.yml
@@ -1,5 +1,5 @@
 ---
-# Copyright 2021, Sherwin Daganato <sherwin@daganato.com>
+# Copyright 2017, Jean-Philippe Evrard <jean-philippe@evrard.me>
 #
 # Licensed under the Apache License, Version 2.0 (the "License");
 # you may not use this file except in compliance with the License.
@@ -13,14 +13,17 @@
 # See the License for the specific language governing permissions and
 # limitations under the License.
 
-keepalived_package_name: "keepalived"
-keepalived_service_name: "keepalived"
-keepalived_config_directory_path: "/etc/keepalived"
-keepalived_config_base_file: "keepalived.conf"
-_keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
-
-# Packages for Selinux
-keepalived_selinux_packages:
-  - python3-policycoreutils
-  - libselinux
-  - libselinux-devel
+keepalived_sync_groups:
+  haproxy:
+    instances:
+      - int
+keepalived_instances:
+  internal:
+    state: absent
+  int:
+    interface: "{{ vrrp_nic }}"
+    state: "{{ (groups['all'].index(inventory_hostname) == 0) | ternary('MASTER','BACKUP') }}"
+    virtual_router_id: 42
+    priority: "{{ (groups['all']|length - groups['all'].index(inventory_hostname)) * 250 // (groups['all']|length) }}"
+    vips:
+      - "192.168.33.2/24 dev {{ vrrp_nic }}"

--- a/tests/keepalived_haproxy_master_edit_example.yml
+++ b/tests/keepalived_haproxy_master_edit_example.yml
@@ -1,0 +1,246 @@
+---
+# Copyright 2015, Jean-Philippe Evrard <jean-philippe@evrard.me>
+#
+# Licensed under the Apache License, Version 2.0 (the "License");
+# you may not use this file except in compliance with the License.
+# You may obtain a copy of the License at
+#
+#     http://www.apache.org/licenses/LICENSE-2.0
+#
+# Unless required by applicable law or agreed to in writing, software
+# distributed under the License is distributed on an "AS IS" BASIS,
+# WITHOUT WARRANTIES OR CONDITIONS OF ANY KIND, either express or implied.
+# See the License for the specific language governing permissions and
+# limitations under the License.
+
+keepalived_sync_groups:
+  # You can have multiple sync groups. Here is an example of just one.
+  haproxy:
+    # Each group can have muliple instances
+    instances:
+      - ext
+      - int
+    # Uncomment this to have a notification script, triggered on state change.
+    # all the *_scripts can be a direct command, or a path to a script
+    # For the latter, you MUST define a script that will be used a source in
+    # src_*_script (available on the deployment host).
+    # The src_*_script will be uploaded to your destination host at the _script
+    # location
+    #notify_script: /etc/keepalived/haproxy_notify.sh
+    #src_notify_script: <path to source script if notify_script is not a command>
+    # If instead of one notification script handling all types of events, you
+    # want to define script per type of notification, please uncomment this.
+    # They will act before the general notification script.
+    # Their deployment and configuration are like the notify_script
+    #notify_master:
+    #src_notify_master:
+    #notify_backup:
+    #src_notify_backup:
+    #notify_fault:
+    #src_notify_fault:
+
+# Uncomment this to have keepalived status checking. They will run on all the hosts
+# whether it's master or backup. You can have multiple scripts.
+#keepalived_scripts:
+  #haproxy_check_script:
+    # Here is an example with a command instead of a script.
+    # Add src_check_script if you want to run a script instead of a command
+    # and upload it from your deploy host
+    #check_script: "killall -0 haproxy"
+  #pingable_check_script:
+    #check_script: "ping -c 1 193.0.14.129 1>&2"
+    # Interval is the time in seconds between each check
+    #interval: 10
+    # Fall is the time to mark the keepalived status as not ok
+    #fall: 2
+    # Rise is the time to mark the keepalived status as back to ok
+    #rise: 4
+    # Allow the check script to complete within a timeout
+    #timeout: 2
+
+keepalived_instances:
+  #This dict name is the same as the one above, in keepalived_sync_groups.
+  external:
+    state: absent
+  ext:
+    #remember you can use ansible variables here.
+    interface: eth0
+    state: MASTER
+    virtual_router_id: 100
+    priority: 95
+    #Optional, VRRP Advert interval in seconds
+    #advert_int: 1
+    # Please set this if you want to use a virtual MAC address.
+    #use_vmac: true
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    vips:
+      - "{{ keepalived_external_vip_cidr }} dev eth0"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+    # Optional virtual_ipaddress_excluded section
+    #vips_excluded:
+    #  - "10.0.0.1 dev eth0"
+  internal:
+    state: absent
+  int:
+    interface: eth1
+    state: MASTER
+    virtual_router_id: 110
+    priority: 95
+    # Please set this if you want to use authentication in your VRRP
+    # instance. If more than 8 characters, it will be truncated.
+    # The password must be the same per router_id (so backup and
+    # master should have the same password).
+    #authentication_password: "your_password"
+    # Optional Scripts for tracking the current status of the keepalived instance
+    #track_scripts:
+    #  - haproxy_check_script
+    #  - pingable_check_script
+    # Optional Interfaces for tracking the link status of the interfaces listed
+    #track_interfaces:
+    #  - eth1
+    #  - eth2
+    vips:
+      - "{{ keepalived_internal_vip_cidr }} dev eth1"
+
+# Uncomment and adjust to make use of keepalived's virtual_server functions.
+#keepalived_virtual_servers:
+#  # Example with recycled {{ keepalived_internal_vip_cidr }}
+#  - IP: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#    port: '53'
+#    protocol: 'UDP'
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    real_servers:
+#      - IP: '8.8.8.8'
+#        port: '53'
+#        # Optional, relative weight to use, default: 1
+#        weight: 3
+#        # Optional, maximum number of connections to server
+#        uthreshold: 1000
+#        # Optional, minimum number of connections to server
+#        lthreshold: 1000
+#        # Section is optional.
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.8.8'
+#              # Role default is 3
+#              misc_timeout: '2'
+#      - IP: '8.8.4.4'
+#        port: '53'
+#        misc_check:
+#            - misc_path: '/usr/bin/host -W 1 github.com 8.8.4.4'
+#              # Optional
+#              misc_timeout: '10'
+#              # Optional, set false or omit to not use it.
+#              warmup: true
+#              # Optional, set false or omit to not use it.
+#              misc_dynamic: true
+#              # Optional, Specify the username/groupname that the script should
+#                          be run under.
+#                          If group is not specified, the group of the user
+#                          is used
+#              user: 'root'
+#              group: 'root'
+#        ssl_get:
+#          - url_path: '/'
+#            url_digest: 'a797b47875d8fd5c949066182902099d'
+#            # Optional
+#            connect_timeout: 3
+#            # Optional
+#            nb_get_retry: 3
+#            # Optional
+#            delay_before_retry: 2
+#            # Optional, IP to connect to, if not set real_server IP will be used
+#            connect_ip: '10.0.0.1'
+#            # Optional, Port to connect to, if not set real_server Port will be used
+#            connect_port: 443
+#            # Optional, source IP
+#            bindto: '10.0.0.2'
+#            # Optional, fwmark to mark all outgoing checker packets with
+#            fwmark: 2
+#            # Optional, random delay to start the initial check
+#            warmup: 2
+#        http_get:
+#          - url_path: '/'
+#            url_digest: 'a797b47875d8fd5c949066182902099d'
+#            # Optional
+#            connect_timeout: 3
+#            nb_get_retry: 3
+#            delay_before_retry: 2
+#            # Optional, IP to connect to, if not set real_server IP will be used
+#            connect_ip: '10.0.0.1'
+#            # Optional, Port to connect to, if not set real_server Port will be used
+#            connect_port: 80
+#            # Optional, source IP
+#            bindto: '10.0.0.2'
+#            # Optional, Optional fwmark to mark all outgoing checker packets with
+#            fwmark: 2
+#            # Optional random delay to start the initial check
+#            warmup: 2
+#        tcp_checks:
+#            #Port to connect to
+#            connect_port: 23
+#            # Optional, IP to connect to, if not set real_server IP will be used
+#            connect_ip: '10.0.0.1'
+#            # Optional
+#            connect_timeout: 3
+#            # Optional
+#            retry: 3
+#            # Optional
+#            delay_before_retry: 2
+#            # Optional, source IP
+#            bindto: '10.0.0.2'
+#            # Optional, fwmark to mark all outgoing checker packets with
+#            fwmark: 2
+#            # Optional, random delay to start the initial check
+#            warmup: 2
+#        dns_checks:
+#            # IP to connect to
+#            connect_ip: '10.0.0.1'
+#            # Optional, Port to connect to, if not set real_server Port will be used
+#            connect_port: 1053
+#            # Optional
+#            connect_timeout: 3
+#            # Optional
+#            retry: 3
+#            # Optional, source IP
+#            bindto: '10.0.0.2'
+#            # Optional, fwmark to mark all outgoing checker packets with
+#            fwmark: 2
+#            # Optional, DNS type to query (SOA is default)
+#            type: SOA
+#            # Optional, DNS name to query ("." is default)
+#            name: '.'
+#
+#
+# # Define Keepalived Virtual Server Groups
+#
+#keepalived_virtual_server_groups:
+#  - name: server_group_1
+#    # Multiple VIPs (configured in keepalived_instances) are allowed, incl. IP Ranges
+#    vips:
+#      - ip: 10.0.0.1
+#        port: 80
+#    # Optional, define protocol (TCP is default)
+#    protocol: 'TCP'
+#    # Optional, LVS Scheduler (rr is default)
+#    lvs_sched: 'rr'
+#    # Optional, LVS Method (DR is default)
+#    lvs_method: 'NAT'
+#    # Optional, set false or omit to not use it.
+#    ha_suspend: true
+#    # Optional, iptables fwmark
+#    fwmark: 2
+#    real_servers:
+#    # -> same config/check options like keepalived_virtual_servers

--- a/tests/keepalived_haproxy_master_edit_example.yml
+++ b/tests/keepalived_haproxy_master_edit_example.yml
@@ -116,7 +116,7 @@ keepalived_instances:
 # Uncomment and adjust to make use of keepalived's virtual_server functions.
 #keepalived_virtual_servers:
 #  # Example with recycled {{ keepalived_internal_vip_cidr }}
-#  - IP: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#  - IP: "{{ keepalived_internal_vip_cidr | ansible.netcommon.ipaddr('address') }}"
 #    port: '53'
 #    protocol: 'UDP'
 #    lvs_method: 'NAT'

--- a/tests/keepalived_haproxy_master_example.yml
+++ b/tests/keepalived_haproxy_master_example.yml
@@ -112,7 +112,7 @@ keepalived_instances:
 # Uncomment and adjust to make use of keepalived's virtual_server functions.
 #keepalived_virtual_servers:
 #  # Example with recycled {{ keepalived_internal_vip_cidr }}
-#  - IP: "{{ keepalived_internal_vip_cidr | ipaddr('address') }}"
+#  - IP: "{{ keepalived_internal_vip_cidr | ansible.netcommon.ipaddr('address') }}"
 #    port: '53'
 #    protocol: 'UDP'
 #    lvs_method: 'NAT'

--- a/tests/playbook-with-combined-vars.yml
+++ b/tests/playbook-with-combined-vars.yml
@@ -20,8 +20,19 @@
     vrrp_nic: eth0
   tasks:
   - name: Include a single (combined) var file for all nodes
-    include_vars: "keepalived_haproxy_combined_example.yml"
+    ansible.builtin.include_vars: "keepalived_haproxy_combined_example.yml"
 
   - name: "Include ansible-keepalived"
-    include_role:
-      name: "ansible-keepalived"
+    ansible.builtin.include_role:
+      name: ansible-keepalived
+
+  - name: half way done
+    ansible.builtin.debug:
+      msg: "--- --- --- --- UPDATE CONFIGURATION --- --- --- ---"
+
+  - name: Include a single (combined) edit var file for all nodes
+    ansible.builtin.include_vars: "keepalived_haproxy_combined_edit_example.yml"
+
+  - name: "Include ansible-keepalived"
+    ansible.builtin.include_role:
+      name: ansible-keepalived

--- a/tests/playbook-with-fine-grained-vars.yml
+++ b/tests/playbook-with-fine-grained-vars.yml
@@ -4,11 +4,11 @@
   # You can define the equivalent of the include_vars there.
   tasks:
   - name: Include the variables for the master configuration
-    include_vars: "keepalived_haproxy_master_example.yml"
+    ansible.builtin.include_vars: "keepalived_haproxy_master_example.yml"
 
-  - name: "Include ansible-keepalived"
-    include_role:
-      name: "ansible-keepalived"
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived
 
 - name: Install keepalived on the rest of the nodes for haproxy use
   hosts: all:!master_node
@@ -17,8 +17,33 @@
   # host instead of include_vars, but hey, this is just an example.
   tasks:
   - name: Include the var file for all the other nodes
-    include_vars: "keepalived_haproxy_backup_example.yml"
+    ansible.builtin.include_vars: "keepalived_haproxy_backup_example.yml"
 
-  - name: "Include ansible-keepalived"
-    include_role:
-      name: "ansible-keepalived"
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived
+
+- name: Edit keepalived on master node intances
+  hosts: master_node
+  # The VRRP NIC is defined in group/host vars
+  # You can define the equivalent of the include_vars there.
+  tasks:
+  - name: Include the variables for the master configuration
+    ansible.builtin.include_vars: "keepalived_haproxy_master_edit_example.yml"
+
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived
+
+- name: Edit keepalived on the rest of the nodes instances
+  hosts: all:!master_node
+  # VRRP NIC variable is defined in inventory
+  # You should probably fine grain the variables of keepalived per
+  # host instead of include_vars, but hey, this is just an example.
+  tasks:
+  - name: Include the var file for all the other nodes
+    ansible.builtin.include_vars: "keepalived_haproxy_backup_edit_example.yml"
+
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived

--- a/vars/debian.yml
+++ b/vars/debian.yml
@@ -15,7 +15,8 @@
 
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
-keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_config_directory_path: "/etc/keepalived"
+keepalived_config_base_file: "keepalived.conf"
 _keepalived_daemon_options_file_path: "/etc/default/keepalived"
 
 # Packages for Selinux

--- a/vars/redhat-7.yml
+++ b/vars/redhat-7.yml
@@ -16,7 +16,8 @@
 # Standard names and paths for CentOS 7
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
-keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_config_directory_path: "/etc/keepalived"
+keepalived_config_base_file: "keepalived.conf"
 _keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
 
 keepalived_selinux_packages:

--- a/vars/redhat.yml
+++ b/vars/redhat.yml
@@ -15,7 +15,8 @@
 
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
-keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_config_directory_path: "/etc/keepalived"
+keepalived_config_base_file: "keepalived.conf"
 _keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
 
 # Packages for Selinux

--- a/vars/suse.yml
+++ b/vars/suse.yml
@@ -15,7 +15,8 @@
 
 keepalived_package_name: "keepalived"
 keepalived_service_name: "keepalived"
-keepalived_config_file_path: "/etc/keepalived/keepalived.conf"
+keepalived_config_directory_path: "/etc/keepalived"
+keepalived_config_base_file: "keepalived.conf"
 _keepalived_daemon_options_file_path: "/etc/sysconfig/keepalived"
 
 # Packages for Selinux


### PR DESCRIPTION
* split ``task/main.yml`` in multiple files

* use FQCN

* use ``ansible_managed | comment`` 

* use loop instead of with_*

* split keepalived configs into separated directories / files

* ``keepalived_instances.INSTANCE.state`` is multiuse (the configuration file state / optional configuration state) -> ``absent | d(present) / ['MASTER', 'BACKUP']``