### PR TITLE
Make way for using dependabot for requirements

### DIFF
--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,5 +1,5 @@
 molecule-docker
 molecule
 molecule[docker]
-ansible-lint
+ansible-lint<=5.4.0
 yamllint

--- a/tox.ini
+++ b/tox.ini
@@ -6,7 +6,7 @@ skipsdist = true
 [testenv]
 passenv = *
 deps =
-    -rtox-requirements.txt
+    -rdev-requirements.txt
     ansible-2.10: ansible==2.10
     ansible-latest: ansible
 commands =


### PR DESCRIPTION
dependabot only understand {dev-,test-,}requirements.txt.
We need to rename the tox-requirements into dev-requirements,
so that dependabot can maintain it.

We can then freeze the dependencies in test, and use dependabot
to automatically bump the deps.

This will increase stability for maintainers (no PR will fail due
to test env), while at the same time we will have dependabot to
still show us the issues originated from upstream changes
on a more frequent basis.