### PR TITLE
Ensure a masked unit does not break the role

### DIFF
--- a/molecule/default/cleanup.yml
+++ b/molecule/default/cleanup.yml
@@ -1,5 +1,5 @@
 ---
-- name: Prepare molecule instance
+- name: Cleanup default molecule scenario
   hosts: all[0]
   gather_facts: no
   tasks:

--- a/molecule/masked-keepalived/cleanup.yml
+++ b/molecule/masked-keepalived/cleanup.yml
@@ -1,0 +1,10 @@
+---
+- name: Cleanup molecule masked-keepalived scenario
+  hosts: all[0]
+  gather_facts: no
+  tasks:
+  - name: Remove masked keepalived docker network
+    delegate_to: localhost
+    community.docker.docker_network:
+      name: masked-keepalived-network
+      state: absent

--- a/molecule/masked-keepalived/converge.yml
+++ b/molecule/masked-keepalived/converge.yml
@@ -1,0 +1,48 @@
+---
+- name: Converge
+  hosts: all
+  tasks:
+  - name: Apt update and install rsync, ping, iproute
+    ansible.builtin.package:
+      update_cache: yes
+      name:
+        - rsync
+        - inetutils-ping
+        - iproute2
+      state: present
+    when: ansible_os_family == "Debian"
+
+  - name: Add a container to a network, leaving existing containers connected
+    delegate_to: localhost
+    community.docker.docker_network:
+      name: masked-keepalived-network
+      connected:
+        - "{{ inventory_hostname }}"
+      appends: yes
+
+  - name: Re-collect network facts required after installation iproute
+    ansible.builtin.setup:
+      gather_subset: network
+
+  - name: Show ansible_interfaces
+    ansible.builtin.debug:
+      var: ansible_interfaces
+
+  - name: Define vrrp nic
+    ansible.builtin.set_fact:
+      vrrp_nic: "{{ ((ansible_interfaces | reject('equalto','lo')) | difference([ansible_default_ipv4.interface]))[0] | string }}"
+
+  - name: Define keepalived config
+    ansible.builtin.set_fact:
+      keepalived_instances:
+        internal:
+          interface: "{{ vrrp_nic }}"
+          state: "MASTER"
+          virtual_router_id: 120
+          priority: 150
+          vips:
+            - "192.168.120.2/24 dev {{ vrrp_nic }}"
+
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived

--- a/molecule/masked-keepalived/molecule.yml
+++ b/molecule/masked-keepalived/molecule.yml
@@ -1,0 +1,20 @@
+---
+dependency:
+  name: galaxy
+driver:
+  name: docker
+verifier:
+  name: ansible
+provisioner:
+  name: ansible
+  options:
+    v: True
+  log: True
+platforms:
+  - name: masked-keepalived-focal
+    pre_build_image: yes
+    image: geerlingguy/docker-ubuntu2004-ansible:latest
+    privileged: true
+    command: /lib/systemd/systemd
+    volumes:
+    - /sys/fs/cgroup:/sys/fs/cgroup:ro

--- a/molecule/masked-keepalived/prepare.yml
+++ b/molecule/masked-keepalived/prepare.yml
@@ -1,0 +1,12 @@
+---
+- name: Prepare molecule instance
+  hosts: all[0]
+  tasks:
+  - name: Create a masked keepalived network
+    delegate_to: localhost
+    community.docker.docker_network:
+      name: masked-keepalived-network
+      ipam_config:
+        - subnet: 192.168.120.0/24
+          gateway: 192.168.120.254
+          iprange: 192.168.120.0/26

--- a/molecule/masked-keepalived/side_effect.yml
+++ b/molecule/masked-keepalived/side_effect.yml
@@ -1,0 +1,17 @@
+---
+- name: Side effect playbook
+  hosts: all
+  tasks:
+  - name: Stop the service to throw a wrench in the plan
+    ansible.builtin.command: "systemctl stop keepalived.service"
+    tags:
+      - skip_ansible_lint
+
+  - name: Now mask the service to really throw a wrench in the plan
+    ansible.builtin.command: "systemctl mask keepalived.service"
+    tags:
+      - skip_ansible_lint
+
+  - name: Include ansible-keepalived
+    ansible.builtin.include_role:
+      name: ansible-keepalived

--- a/molecule/masked-keepalived/verify.yml
+++ b/molecule/masked-keepalived/verify.yml
@@ -1,0 +1,21 @@
+---
+# This ensures that keepalived is started
+
+- name: Verify
+  hosts: all[0]
+  order: sorted
+  gather_facts: yes
+  tasks:
+    - name: Populate service facts
+      ansible.builtin.service_facts:
+
+    - name: Show ansible facts for keepalived
+      ansible.builtin.debug:
+        var: ansible_facts.services
+        verbosity: 3
+
+    - name: Ensure keepalived is started
+      ansible.builtin.assert:
+        that:
+          - "ansible_facts.services['keepalived.service']['state'] == 'running'"
+          - "ansible_facts.services['keepalived.service']['status'] == 'enabled'"

--- a/tox.ini
+++ b/tox.ini
@@ -11,4 +11,4 @@ deps =
     ansible-latest: ansible
 commands =
     ansible-galaxy collection install community.docker
-    molecule test
+    molecule test --all


### PR DESCRIPTION
Without this, we can't ensure that a masked unit does not break
the role. This is necessary to revert some code and use upstream
modules again.