### PR TITLE
Fix meta for ansible-lint

### DIFF
--- a/meta/main.yml
+++ b/meta/main.yml
@@ -14,27 +14,28 @@
 # limitations under the License.
 
 galaxy_info:
-  role_name: keepalived
-  author: evrardjp
-  description:  This role installs and configure keepalived based on a variable file
-  license: Apache
-  min_ansible_version: 2.10
+  role_name: "keepalived"
+  author: "evrardjp"
+  description: "This role installs and configure keepalived based on a simple dict"
+
+  license: "Apache-2.0"
+
+  min_ansible_version: "2.10"
+
   platforms:
-  - name: EL
+  - name: "EL"
     versions:
-    - 7
-    - 8
-  - name: Ubuntu
+    - "7"
+    - "8"
+  - name: "Ubuntu"
     versions:
-    - xenial
-    - bionic
-    - focal
-  - name: opensuse
-    versions:
-    - all
-  - name: Debian
-    versions:
-    - stretch
+    - "xenial"
+    - "bionic"
+    - "focal"
+  - name: "Debian"
   galaxy_tags:
-  - clustering
+  - "clustering"
+  - "networking"
+  - "system"
+
 dependencies: []


### PR DESCRIPTION
ansible-lint now needs strings and is now inspecting the schema.
We should do the right thing (TM) by ensuring the data types are
correct.

Side note: The Ansible version is not a numeric type and needs to
be a string to pass validation as of today.
