### PR TITLE
Make vips optional

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -146,11 +146,13 @@ vrrp_instance {{ name }} {
   {% endfor %}
   }
   {% endif %}
+  {% if instance.vips is defined and instance.vips | length > 0 %}
   virtual_ipaddress {
     {% for vip in instance.vips %}
     {{ vip }}
     {% endfor %}
   }
+  {% endif %}
   {% if instance.vips_excluded is defined and instance.vips_excluded | length > 0 %}
   virtual_ipaddress_excluded {
     {% for vip in instance.vips_excluded %}


### PR DESCRIPTION
Without this patch, it's impossible to have keepalived working
without a VIP (for the rare cases without VIPs).

Closes: #167 