### PR TITLE
Split ansible-2.10 requirements from dev

### DIFF
--- a/ansible210-requirements.txt
+++ b/ansible210-requirements.txt
@@ -1,0 +1,7 @@
+# Frozen requirements for ansible 2.10
+ansible>=2.10,<2.11
+molecule-docker==1.1.0
+molecule==4.0.0
+molecule[docker]==4.0.0
+ansible-lint<5.4.0
+yamllint==1.27.1

--- a/dev-requirements.txt
+++ b/dev-requirements.txt
@@ -1,3 +1,5 @@
+# Ansible-latest test environment
+ansible
 molecule-docker==2.0.0
 molecule==4.0.0
 molecule[docker]==4.0.0

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -19,6 +19,9 @@
         RedHat:
           - iproute
           - iputils
+        Rocky:
+          - iproute
+          - iputils
 
   - name: Add a container to a network, leaving existing containers connected
     delegate_to: localhost

--- a/molecule/default/converge.yml
+++ b/molecule/default/converge.yml
@@ -7,6 +7,10 @@
     - "1"
     - "100%"
   tasks:
+  - name: Show some details for debug
+    ansible.builtin.debug:
+      msg: "Family {{ ansible_os_family }} and ansible version {{ ansible_version['string'] }}"
+
   - name: Install basic packages
     ansible.builtin.package:
       update_cache: "{{ ansible_os_family == 'Debian' | ternary('yes', omit) }}"

--- a/tox.ini
+++ b/tox.ini
@@ -5,10 +5,14 @@ skipsdist = true
 
 [testenv]
 passenv = *
-deps =
-    -rdev-requirements.txt
-    ansible-2.10: ansible==2.10
-    ansible-latest: ansible
 commands =
     ansible-galaxy collection install community.docker
     molecule test --all
+
+[testenv:ansible-2.10]
+deps =
+    -r ansible210-requirements.txt
+
+[testenv:ansible-latest]
+deps =
+    -r dev-requirements.txt


### PR DESCRIPTION
The ansible package ansible==2.10 is NOT having the proper
constraint to matching ansible-base/ansible-core. So it means
that pip happily installs ansible==2.10 then installs
ansible-core 2.13. This means the code actually running
in ansible-2.10 testing is ansible-2.13.

This is a problem, as the testing for ansible-2.10 is not
actually testing 2.10.

This fixes it by splitting the two test environments, having two
different requirements files. We do not lock or constrain
(yet!) the dependencies, as this would mean extra effort
in the tooling.

In the meantime, contributors should ensure that the right
version of ansible-core/base is installed.