### PR TITLE
Add support for checkmode in tasks/main.yml

### DIFF
--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -60,6 +60,7 @@
   ansible.builtin.command: keepalived --version
   register: _keepalived_version
   changed_when: false
+  check_mode: no
   tags:
     - keepalived-config
 


### PR DESCRIPTION
I'm not able to run the playbook in check mode due to the "Output keepalived version" task. ansible.builtin.command doesn't run in check mode because it assumes changes are being made. No changes are being made in this case, so I've added 'check_mode: no'.

Docs for the check_mode option are here: https://docs.ansible.com/ansible/latest/user_guide/playbooks_checkmode.html#enforcing-or-preventing-check-mode-on-tasks