### PR TITLE
Fixes conditional logic and other issues with dropping scripts

### DIFF
--- a/defaults/main.yml
+++ b/defaults/main.yml
@@ -25,6 +25,21 @@ keepalived_selinux_compile_rules:
 #keepalived_package_state: "latest"
 keepalived_package_state: "{{ ( (keepalived_use_latest_stable | default(true)) | bool) | ternary('latest','present') }}"
 
+# Keepalived scripts can be defined that trigger notification scripts.
+# Examples have been provided below and in the tests directory.
+# keepalived_scripts:
+  #haproxy_check_script:
+    # check_script: "/etc/keepalived/haproxy_check.sh"
+    # ##if a src_check_script is defined, it will be uploaded from src_check_script
+    # ##on the deploy host to the check_script location. If the check_script needs
+    # ##parameters, you can define the location under dest_check_script.
+    # src_check_script: "{{ playbook_dir }}/../scripts/keepalived_haproxy_check.sh"
+  #haproxy_check_script:
+    # Here is an example with a command instead of a script.
+    # Add src_check_script if you want to run a script instead of a command
+    #check_script: "killall -0 haproxy"
+keepalived_scripts: {}
+
 # Keepalived scripts may rely upon additional packages.
 keepalived_scripts_packages: []
 

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -125,17 +125,6 @@
   tags:
     - keepalived-install
 
-- name: Configure keepalived
-  ansible.builtin.template:
-    src: keepalived.conf.j2
-    dest: "{{ keepalived_config_file_path }}"
-    mode: "0640"
-    validate: "{{ keepalived_config_testable | ternary('keepalived --config-test -f %s', omit) }}"
-  notify:
-    - reload keepalived
-  tags:
-    - keepalived-config
-
 - name: Check that daemon options file exists
   ansible.builtin.stat:
     path: "{{ keepalived_daemon_options_file_path }}"
@@ -161,8 +150,8 @@
     src: "{{ item.value.src_check_script }}"
     dest: "{{ item.value.dest_check_script | default(item.value.check_script) }}"
     mode: "0755"
-  loop: "{{ keepalived_sync_groups | dict2items | default('{}') }}"
-  when: item.value.src_check_script is defined
+  loop: "{{ keepalived_scripts | dict2items | default('{}') }}"
+  when: "'src_check_script' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -283,6 +272,17 @@
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
   when: item.value.src_notify_fault is defined
+  notify:
+    - reload keepalived
+  tags:
+    - keepalived-config
+
+- name: Configure keepalived
+  ansible.builtin.template:
+    src: keepalived.conf.j2
+    dest: "{{ keepalived_config_file_path }}"
+    mode: "0640"
+    validate: "{{ keepalived_config_testable | ternary('keepalived --config-test -f %s', omit) }}"
   notify:
     - reload keepalived
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -163,7 +163,7 @@
     dest: "{{ item.value.notify_script }}"
     mode: "0755"
   loop: "{{ keepalived_sync_groups | dict2items }}"
-  when: item.value.src_notify_script is defined
+  when: "'src_notify_script' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -175,7 +175,7 @@
     dest: "{{ item.value.notify_master }}"
     mode: "0755"
   loop: "{{ keepalived_sync_groups | dict2items }}"
-  when: item.value.src_notify_master is defined
+  when: "'src_notify_master' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -187,7 +187,7 @@
     dest: "{{ item.value.notify_backup }}"
     mode: "0755"
   loop: "{{ keepalived_sync_groups | dict2items }}"
-  when: item.value.src_notify_backup is defined
+  when: "'src_notify_backup' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -199,7 +199,7 @@
     dest: "{{ item.value.notify_fault }}"
     mode: "0755"
   loop: "{{ keepalived_sync_groups | dict2items }}"
-  when: item.value.src_notify_fault is defined
+  when: "'src_notify_fault' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -211,7 +211,7 @@
     dest: "{{ item.value.notify_script }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_script is defined
+  when: "'src_notify_script' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -223,7 +223,7 @@
     dest: "{{ item.value.notify_master }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_master is defined
+  when: "'src_notify_master' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -235,7 +235,7 @@
     dest: "{{ item.value.notify_master_rx_lower_pri }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_master_rx_lower_pri is defined
+  when: "'src_notify_master_rx_lower_pri' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -247,7 +247,7 @@
     dest: "{{ item.value.notify_backup }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_backup is defined
+  when: "'src_notify_backup' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -259,7 +259,7 @@
     dest: "{{ item.value.notify_stop }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_stop is defined
+  when: "'src_notify_stop' in item.value"
   notify:
     - reload keepalived
   tags:
@@ -271,7 +271,7 @@
     dest: "{{ item.value.notify_fault }}"
     mode: "0755"
   loop: "{{ keepalived_instances | dict2items }}"
-  when: item.value.src_notify_fault is defined
+  when: "'src_notify_fault' in item.value"
   notify:
     - reload keepalived
   tags:

--- a/tasks/main.yml
+++ b/tasks/main.yml
@@ -150,7 +150,7 @@
     src: "{{ item.value.src_check_script }}"
     dest: "{{ item.value.dest_check_script | default(item.value.check_script) }}"
     mode: "0755"
-  loop: "{{ keepalived_scripts | dict2items | default('{}') }}"
+  loop: "{{ keepalived_scripts | dict2items }}"
   when: "'src_check_script' in item.value"
   notify:
     - reload keepalived


### PR DESCRIPTION
This patch addresses a few issues with recent changes, including:

- The 'validate' template directive fails due to check scripts not yet being dropped
- The scripts not being dropped due to the conditional not being met
- keepalived_scripts being changed to keepalived_sync_groups (inadvertently?)

NOTE: This patch only addresses the tracking scripts, but may need to be modified to address similar issues with other notification scripts. 