### PR TITLE
Disable CI until a solution for molecule is found

### DIFF
--- a/tox.ini
+++ b/tox.ini
@@ -11,7 +11,9 @@ setenv =
     LC_TIME = en_US.UTF-8
 commands =
     ansible-galaxy collection install community.docker
-    molecule test --all
+    yamllint .
+    ansible-lint -v --exclude=.tox
+    #molecule test --all
 
 [testenv:ansible-2.10]
 deps =


### PR DESCRIPTION
I frequently have to deal with broken CI due to system changes:
- systemd gets updated, and start to break cgroup integration of docker
- docker includes a bug, so molecule tests starts to fail
- molecule gets updated, dependencies are a mess
- molecule[docker] gets updated, same issues.

I am tired of maintaining this fragile CI. I will remove it.

There is no less fragile option that I know of.

Github actions could be used to test basic features, like deployment. It cannot test the clustering, as we do not have an inventory containing multiple nodes.

If anyone is interested by brining the test coverage back, I am fine with it, please submit a PR.