### PR TITLE
Support absolute paths for SELinux modules

### DIFF
--- a/tasks/keepalived_selinux.yml
+++ b/tasks/keepalived_selinux.yml
@@ -24,7 +24,7 @@
     name: "{{ keepalived_selinux_packages }}"
     state: present
   when:
-    - '"keepalived_ping" not in selinux_modules.stdout'
+    - keepalived_selinux_compile_rules[0] not in selinux_modules.stdout
 
 - name: Compile SELinux rules
   ansible.builtin.include_tasks:
@@ -34,3 +34,5 @@
   loop: "{{ keepalived_selinux_compile_rules }}"
   loop_control:
     loop_var: selinux_policy_name
+  vars:
+    selinux_policy_name_basename: "{{ selinux_policy_name | basename }}"

--- a/tasks/keepalived_selinux_compile.yml
+++ b/tasks/keepalived_selinux_compile.yml
@@ -15,14 +15,14 @@
 
 - name: Create directory for compiling SELinux role
   ansible.builtin.file:
-    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name_basename }}"
     state: directory
     mode: '0755'
 
 - name: Deploy SELinux policy source file
   ansible.builtin.copy:
     src: "{{ selinux_policy_name }}.te"
-    dest: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}/{{ selinux_policy_name }}.te"
+    dest: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name_basename }}/{{ selinux_policy_name_basename }}.te"
     owner: root
     group: root
     mode: "0755"
@@ -30,14 +30,14 @@
 - name: Compile and load SELinux module
   ansible.builtin.command: "{{ item }}"
   args:
-    creates: "/etc/selinux/targeted/active/modules/400/{{ selinux_policy_name }}/cil"
-    chdir: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    creates: "/etc/selinux/targeted/active/modules/400/{{ selinux_policy_name_basename }}/cil"
+    chdir: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name_basename }}"
   loop:
-    - checkmodule -M -m -o {{ selinux_policy_name }}.mod {{ selinux_policy_name }}.te
-    - semodule_package -o {{ selinux_policy_name }}.pp -m {{ selinux_policy_name }}.mod
-    - semodule -i {{ selinux_policy_name }}.pp
+    - checkmodule -M -m -o {{ selinux_policy_name_basename }}.mod {{ selinux_policy_name_basename }}.te
+    - semodule_package -o {{ selinux_policy_name_basename }}.pp -m {{ selinux_policy_name_basename }}.mod
+    - semodule -i {{ selinux_policy_name_basename }}.pp
 
 - name: Remove temporary directory
   ansible.builtin.file:
-    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name }}"
+    path: "/tmp/ansible-keepalived-selinux-{{ selinux_policy_name_basename }}"
     state: absent


### PR DESCRIPTION
Hi,

I like to keep forks of roles to a minimum and often refer to files (like your `keepalived_selinux_compile_rules` list) by absolute paths, usually based on `inventory_dir` or similar. This isn't supported currently as it assumes each item in that list is a filename. This PR adds a new var for the basename which is used in most places. It has no effect on the default values and shouldn't be a breaking change for existing users as I expect it currently fails with relative paths like it does with absolute ones.

I've also changed the check used for installing SELinux packages to check against the first element in `keepalived_selinux_compile_rules` instead of hardcoding `keepalived_ping`, which might be removed by a user overriding the list and thus missing the requirements for compiling modules.