### PR TITLE
Add useful parameters to vserver and checks

### DIFF
--- a/templates/keepalived-checks.j2
+++ b/templates/keepalived-checks.j2
@@ -12,6 +12,9 @@
       {% if tcp_check.retry is defined and tcp_check.retry | int %}
       retry {{ tcp_check.retry }}
       {% endif %}
+      {% if tcp_check.delay_loop is defined and tcp_check.delay_loop | int %}
+      delay_loop {{ tcp_check.delay_loop}}
+      {% endif %}
       {% if tcp_check.delay_before_retry is defined and tcp_check.delay_before_retry | int %}
       delay_before_retry {{ tcp_check.delay_before_retry }}
       {% endif %}
@@ -96,6 +99,9 @@
       connect_timeout {{ http_check.connect_timeout | default('3') }}
       nb_get_retry {{ http_check.nb_get_retry | default('3') }}
       delay_before_retry {{ http_check.delay_before_retry | default('2') }}
+      {% if http_check.delay_loop is defined and http_check.delay_loop | int %}
+      delay_loop {{ http_check.delay_loop}}
+      {% endif %}
       {% if http_check.connect_port is defined and http_check.connect_port %}
       connect_port {{ http_check.connect_port }}
       {% endif %}
@@ -162,6 +168,9 @@
       connect_timeout {{ ssl_check.connect_timeout | default('3') }}
       nb_get_retry {{ ssl_check.nb_get_retry | default('3') }}
       delay_before_retry {{ ssl_check.delay_before_retry | default('2') }}
+      {% if ssl_check.delay_loop is defined and ssl_check.delay_loop | int %}
+      delay_loop {{ ssl_check.delay_loop}}
+      {% endif %}
       {% if ssl_check.connect_port is defined and ssl_check.connect_port %}
       connect_port {{ ssl_check.connect_port }}
       {% endif %}
@@ -228,6 +237,9 @@
       {% if smtp_check.retry is defined and smtp_check.retry | int %}
       retry {{ smtp_check.retry }}
       {% endif %}
+      {% if smtp_check.delay_loop is defined and smtp_check.delay_loop | int %}
+      delay_loop {{ smtp_check.delay_loop}}
+      {% endif %}
       {% if smtp_check.delay_before_retry is defined and smtp_check.delay_before_retry | int %}
       delay_before_retry {{ smtp_check.delay_before_retry }}
       {% endif %}
@@ -263,6 +275,9 @@
       {% if bfd_check.retry is defined and bfd_check.retry | int %}
       retry {{ bfd_check.retry }}
       {% endif %}
+      {% if bfd_check.delay_loop is defined and bfd_check.delay_loop | int %}
+      delay_loop {{ bfd_check.delay_loop}}
+      {% endif %}
       {% if bfd_check.delay_before_retry is defined and bfd_check.delay_before_retry | int %}
       delay_before_retry {{ bfd_check.delay_before_retry }}
       {% endif %}
@@ -290,13 +305,16 @@
     {% if rserver.ping_checks is defined %}
     {% for ping_check in rserver.ping_checks %}
     PING_CHECK {
-      connect_port {{ ping_check.connect_port }}
+      connect_port {{ ping_check.connect_port | default(8080) }}
       connect_timeout {{ ping_check.connect_timeout | default('5') }}
       {% if ping_check.connect_ip is defined and ping_check.connect_ip %}
       connect_ip {{ ping_check.connect_ip }}
       {% endif %}
       {% if ping_check.retry is defined and ping_check.retry | int %}
       retry {{ ping_check.retry }}
+      {% endif %}
+      {% if ping_check.delay_loop is defined and ping_check.delay_loop | int %}
+      delay_loop {{ ping_check.delay_loop}}
       {% endif %}
       {% if ping_check.delay_before_retry is defined and ping_check.delay_before_retry | int %}
       delay_before_retry {{ ping_check.delay_before_retry }}
@@ -329,6 +347,9 @@
       {% endif %}
       {% if udp_check.retry is defined and udp_check.retry | int %}
       retry {{ udp_check.retry }}
+      {% endif %}
+      {% if udp_check.delay_loop is defined and udp_check.delay_loop | int %}
+      delay_loop {{ udp_check.delay_loop}}
       {% endif %}
       {% if udp_check.delay_before_retry is defined and udp_check.delay_before_retry | int %}
       delay_before_retry {{ udp_check.delay_before_retry }}
@@ -371,6 +392,9 @@
       {% endif %}
       {% if file_check.delay_before_retry is defined and file_check.delay_before_retry | int %}
       delay_before_retry {{ file_check.delay_before_retry }}
+      {% endif %}
+      {% if file_check.delay_loop is defined and file_check.delay_loop | int %}
+      delay_loop {{ file_check.delay_loop}}
       {% endif %}
       {% if file_check.warmup is defined and file_check.warmup %}
       warmup {{ file_check.warmup }}

--- a/templates/keepalived-checks.j2
+++ b/templates/keepalived-checks.j2
@@ -305,7 +305,9 @@
     {% if rserver.ping_checks is defined %}
     {% for ping_check in rserver.ping_checks %}
     PING_CHECK {
-      connect_port {{ ping_check.connect_port | default(8080) }}
+      {% if ping_check.connect_port is defined and ping_check.connect_port | int %}
+      connect_port {{ ping_check.connect_port }}
+      {% endif %}
       connect_timeout {{ ping_check.connect_timeout | default('5') }}
       {% if ping_check.connect_ip is defined and ping_check.connect_ip %}
       connect_ip {{ ping_check.connect_ip }}

--- a/templates/keepalived-virtual-server.j2
+++ b/templates/keepalived-virtual-server.j2
@@ -7,6 +7,9 @@
   {% endif %}
   lvs_sched {{ vserver.lvs_sched | default ('rr') }}
   lvs_method {{ vserver.lvs_method | default ('DR') }}
+  {% if vserver.quorum is defined and vserver.quorum | int %}
+  quorum {{ vserver.quorum }}
+  {% endif %}
   {% if vserver.persistence_timeout is defined %}
   persistence_timeout {{ vserver.persistence_timeout }}
   {% endif %}


### PR DESCRIPTION
Hello @evrardjp, Jean-Philippe,

I have added 2 parameters to your module:

`vserver.quorum`: allows to define the quorum weight needed to operate properly. If this quorum is not met, the sorry_server will respond instead. This allows for split brain avoidance mechanisms with a witness tie-breaker for example.

`*_check.delay_loop`: this parameter defines the base frequency with which health checks are done. `delay_before_retry` is an override for this parameter only in the case of failures. By setting `delay_loop` to an integer, the healthcheck will be run every that-much seconds.

I hope you like it, find it up to your standards, and merge it.