### PR TITLE
Feature: Allow specifying user (and group) for sync group and instance notify scripts

### DIFF
--- a/templates/keepalived.conf.j2
+++ b/templates/keepalived.conf.j2
@@ -96,16 +96,16 @@ vrrp_sync_group {{ name }} {
     {% endfor %}
   }
   {% if sync_group.notify_script is defined %}
-  notify "{{ sync_group.notify_script }}"
+  notify "{{ sync_group.notify_script }}"{{ ' ' if sync_group.notify_script_user_group is defined else ''}}{{sync_group.notify_script_user_group | default('') }}
   {% endif %}
   {% if sync_group.notify_master is defined %}
-  notify_master "{{ sync_group.notify_master }}"
+  notify_master "{{ sync_group.notify_master }}"{{ ' ' if sync_group.notify_master_user_group is defined else ''}}{{sync_group.notify_master_user_group | default('') }}
   {% endif %}
   {% if sync_group.notify_backup is defined %}
-  notify_backup "{{ sync_group.notify_backup }}"
+  notify_backup "{{ sync_group.notify_backup }}"{{ ' ' if sync_group.notify_backup_user_group is defined else ''}}{{sync_group.notify_backup_user_group | default('') }}
   {% endif %}
   {% if sync_group.notify_fault is defined %}
-  notify_fault "{{ sync_group.notify_fault }}"
+  notify_fault "{{ sync_group.notify_fault }}"{{ ' ' if sync_group.notify_fault_user_group is defined else ''}}{{sync_group.notify_fault_user_group | default('') }}
   {% endif %}
   {% if sync_group.global_tracking is defined and sync_group.global_tracking | bool %}
   global_tracking                                # All VRRP share the same tracking config.
@@ -248,22 +248,22 @@ vrrp_instance {{ name }} {
   {% endif %}
 
   {% if instance.notify_script is defined %}
-  notify "{{ instance.notify_script }}"
+  notify "{{ instance.notify_script }}"{{ ' ' if instance.notify_script_user_group is defined else ''}}{{instance.notify_script_user_group | default('') }}
   {% endif %}
   {% if instance.notify_master is defined %}
-  notify_master "{{ instance.notify_master }}"
+  notify_master "{{ instance.notify_master }}"{{ ' ' if instance.notify_master_user_group is defined else ''}}{{instance.notify_master_user_group | default('') }}
   {% endif %}
   {% if instance.notify_master_rx_lower_pri is defined %}
-  notify_master_rx_lower_pri "{{ instance.notify_master_rx_lower_pri }}"
+  notify_master_rx_lower_pri "{{ instance.notify_master_rx_lower_pri }}"{{ ' ' if instance.notify_master_rx_lower_pri_user_group is defined else ''}}{{instance.notify_master_rx_lower_pri_user_group | default('') }}
   {% endif %}
   {% if instance.notify_backup is defined %}
-  notify_backup "{{ instance.notify_backup }}"
+  notify_backup "{{ instance.notify_backup }}"{{ ' ' if instance.notify_backup_user_group is defined else ''}}{{instance.notify_backup_user_group | default('') }}
   {% endif %}
   {% if instance.notify_fault is defined %}
-  notify_fault "{{ instance.notify_fault }}"
+  notify_fault "{{ instance.notify_fault }}"{{ ' ' if instance.notify_fault_user_group is defined else ''}}{{instance.notify_fault_user_group | default('') }}
   {% endif %}
   {% if instance.notify_stop is defined %}
-  notify_stop "{{ instance.notify_stop }}"
+  notify_stop "{{ instance.notify_stop }}"{{ ' ' if instance.notify_stop_user_group is defined else ''}}{{instance.notify_stop_user_group | default('') }}
   {% endif %}
   {% if instance.smtp_alert is defined and instance.smtp_alert | bool %}
   smtp_alert # Send email notification during state transition

--- a/tests/keepalived-install-complex-example.yml
+++ b/tests/keepalived-install-complex-example.yml
@@ -43,14 +43,20 @@
         # For convenience, if you set a variable src_*, the file mentioned in the 'src'
         # will be uploaded from the deployment host to the keepalived server at the
         # notify_script location.
+        # To specify a specific user (and group) to run each script as, set a variable *_user_group'
+        # as seen below.
         #
         # notify_script:
+        # notify_script_user_group:
         # src_notify_script:
         # notify_master:
+        # notify_master_user_group:
         # src_notify_master:
         # notify_backup:
+        # notify_backup_user_group:
         # src_notify_backup:
         # notify_fault:
+        # notify_fault_user_group:
         # src_notify_fault:
 
       # Uncomment this to have keepalived status checking. They will run on all the hosts


### PR DESCRIPTION
## Use Case
Run keepalived with `enable_script_security` and default user `keepalived_script` to run scripts with, but still run some notify scripts with elevated permissions.

## Implementation
Added support for the following optional keys in `keepalived_sync_groups` and `keepalived_instances` to control the user (and group) a notify script runs with:
```yaml
keepalived_sync_groups:
  group:
    notify_script_user_group: user [group]
    notify_master_user_group:  user [group]
    notify_backup_user_group: user [group]
    notify_fault_user_group: user [group]
keepalived_instances:
  instance:
    notify_script_user_group: user [group]
    notify_master_user_group: user [group]
    notify_master_rx_lower_pri_user_group: user [group]
    notify_backup_user_group: user [group]
    notify_fault_user_group: user [group]
    notify_stop_user_group: user [group]
```

Implements #295 

